### PR TITLE
OS9 format track 0 patch

### DIFF
--- a/include/os9path.h
+++ b/include/os9path.h
@@ -142,7 +142,7 @@ error_code _os9_delete_directory(char *pathlist);
 error_code _os9_rename( char *pathlist, char *new_name );
 error_code _os9_rename_ex(char *pathlist, char *new_name, os9_dir_entry *dentry);
 error_code _os9_close(os9_path_id);
-error_code _os9_format(char *pathname, int os968k, int tracks, int sectorsPerTrack, int heads, int sectorSize, int *clusterSize, char *diskName, int sectorAllocationSize, int tpi, int density, int formatEntire, int isDragon, int isHDD, unsigned int *totalSectors, unsigned int *totalBytes);
+error_code _os9_format(char *pathname, int os968k, int tracks, int sectorsPerTrack, int sectorsTrack0, int heads, int sectorSize, int *clusterSize, char *diskName, int sectorAllocationSize, int tpi, int density, int formatEntire, int isDragon, int isHDD, unsigned int *totalSectors, unsigned int *totalBytes);
 
 /* gs.c */
 error_code _os9_gs_attr(os9_path_id, int *);

--- a/librbf/librbfformat.c
+++ b/librbf/librbfformat.c
@@ -16,7 +16,8 @@
 #define DragonBootSize	16	/* Size of Dragon boot area in sectors */
 
 error_code _os9_format(char *pathname, int os968k, int tracks,
-		       int sectorsPerTrack, int heads, int sectorSize,
+		       int sectorsPerTrack, int sectorsTrack0,
+			   int heads, int sectorSize,
 		       int *clusterSize, char *diskName,
 		       int sectorAllocationSize, int tpi, int density,
 		       int formatEntire, int isDragon, int isHDD,
@@ -45,7 +46,7 @@ error_code _os9_format(char *pathname, int os968k, int tracks,
 	/**** Build LSN0 *****/
 	memset(&s0, 0, sizeof(s0));
 
-	*totalSectors = tracks * sectorsPerTrack * heads;
+	*totalSectors = ((tracks * sectorsPerTrack * heads) - sectorsPerTrack) + sectorsTrack0;
 	_int3(*totalSectors, s0.dd_tot);
 
 	*totalBytes = *totalSectors * sectorSize;
@@ -180,7 +181,7 @@ error_code _os9_format(char *pathname, int os968k, int tracks,
 	_int1(0, s0.pd_vfy);
 
 	_int2(sectorsPerTrack, s0.pd_sct);
-	_int2(sectorsPerTrack, s0.pd_t0s);
+	_int2(sectorsTrack0, s0.pd_t0s);
 
 	_int1(3, s0.pd_ilv);
 	_int1(sectorAllocationSize, s0.pd_sas);

--- a/librbf/librbfseek.c
+++ b/librbf/librbfseek.c
@@ -64,6 +64,12 @@ int _os9_lsn_fseek(os9_path_id path, int lsn)
 {
 	long offset;
 
+	if (lsn >= path->t0s)
+	{
+		/* Skip past missing sectors */
+		lsn += path->spt - path->t0s;
+	}
+
 	offset = lsn * path->bps;
 
 	return fseek(path->fd, offset, SEEK_SET);

--- a/os9/os9format.c
+++ b/os9/os9format.c
@@ -33,13 +33,15 @@ static char const *const helpMessage[] = {
 	"     -ss  = single sided (default)\n",
 	"     -ds  = double sided\n",
 	"     -tX  = tracks (default = 35)\n",
-	"     -stX = sectors per track (default = 18)\n",
+	"     -stX = sectors per track (default = 18)\n",	
+	"     -szX = sectors for track 0 (default = 18)\n",
 	"     -dr  = format a Dragon disk\n",
 	" Hard Drive Options:\n",
 	"     -lX  = number of logical sectors\n",
 	NULL
 };
 
+#define DEF_SECTORS_TRACK	18
 
 int os9format(int argc, char **argv)
 {
@@ -48,7 +50,8 @@ int os9format(int argc, char **argv)
 	int i;
 	int tracks = 35;
 	int heads = 1;
-	int sectorsPerTrack = 18;
+	int sectorsPerTrack = DEF_SECTORS_TRACK;
+	int sectorsTrack0 = DEF_SECTORS_TRACK;
 	int bytesPerSector = 256;
 	int tpi = 48;		/* 48 tpi */
 	int density = 1;	/* double density */
@@ -182,8 +185,17 @@ int os9format(int argc, char **argv)
 
 					case 't':
 						sectorsPerTrack = atoi(p + 2);
+						// Change sectors on track 0 only if it's not already been changed.
+						if (DEF_SECTORS_TRACK == sectorsTrack0)
+						{
+							sectorsTrack0 = sectorsPerTrack;
+						}
 						break;
-
+					
+					case 'z':
+						sectorsTrack0 = atoi(p + 2);
+						break;
+						
 					default:
 						fprintf(stderr,
 							"%s: unknown option '%c'\n",
@@ -277,8 +289,8 @@ int os9format(int argc, char **argv)
 
 			error_code ec =
 				_os9_format(argv[i], os968k, tracks,
-					    sectorsPerTrack, heads,
-					    bytesPerSector, &clusterSize,
+					    sectorsPerTrack,sectorsTrack0,
+					    heads, bytesPerSector, &clusterSize,
 					    diskName, sectorAllocationSize,
 					    tpi, density, formatEntire,
 					    isDragon, isHDD, &totalSectors,
@@ -298,6 +310,11 @@ int os9format(int argc, char **argv)
 					       heads);
 					printf("  Sectors/track: %d\n",
 					       sectorsPerTrack);
+					if (sectorsPerTrack != sectorsTrack0)
+					{
+						printf(" Sectors/track0: %d\n",
+								sectorsTrack0);
+					}
 					printf("    Sector size: %d\n",
 					       bytesPerSector);
 					printf("\nLogical Data:\n");

--- a/unittest/librbftest.c
+++ b/unittest/librbftest.c
@@ -16,13 +16,13 @@ void test_os9_format()
 	// test format of a non-existent disk image
 	unsigned int totalSectors, totalBytes;
 	int clusterSize = 0;
-	ec = _os9_format("test.dsk", 0, 35, 18, 1, 256, &clusterSize, "Test Disk", 8, 8,
+	ec = _os9_format("test.dsk", 0, 35, 18, 18, 1, 256, &clusterSize, "Test Disk", 8, 8,
 			 1, 1, 0, 0, &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
 	ASSERT_EQUALS(1, clusterSize);
 
 	// test format of a non-existent disk image with a disk name that is way too long
-	ec = _os9_format("test.dsk", 0, 35, 18, 1, 256, &clusterSize,
+	ec = _os9_format("test.dsk", 0, 35, 18, 18, 1, 256, &clusterSize,
 			 "Test Disk with filename that is way too long for the field",
 			 8, 8, 1, 1, 0, 0, &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
@@ -247,7 +247,7 @@ void test_os9_file_allocation()
 	/* Create disk */
 	unsigned int totalSectors, totalBytes;
 	int clusterSize = 0;
-	ec = _os9_format("test_alloc.dsk", 0, 80, 18, 2, 256, &clusterSize, "Test Allo", 8, 8,
+	ec = _os9_format("test_alloc.dsk", 0, 80, 18, 18, 2, 256, &clusterSize, "Test Allo", 8, 8,
 			 1, 1, 0, 0, &totalSectors, &totalBytes);
 
 	/* Record free space */

--- a/unittest/libtoolshedtest.c
+++ b/unittest/libtoolshedtest.c
@@ -117,7 +117,7 @@ void create_disk(char *name)
 	/* Create disk */
 	unsigned int totalSectors, totalBytes;
 	int clusterSize = 0;
-	ec = _os9_format(name, 0, 80, 18, 2, 256, &clusterSize, "Test LTS", 8, 8,
+	ec = _os9_format(name, 0, 80, 18, 18, 2, 256, &clusterSize, "Test LTS", 8, 8,
 			 1, 1, 0, 0, &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
 }


### PR DESCRIPTION
Patched os9 format so that it can create disks with a different number of sectors on track zero head zero, as this is required by the Dragon Beta/128 OS9 L2 disks.