### PR TITLE
Github Build Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Make Release
+on:
+  workflow_dispatch:
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+permissions:
+  contents: write
+
+defaults:
+    run:
+        shell: bash {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        sudo apt-get install mingw-w64 markdown libfuse-dev
+        sudo make -C build/unix package
+        sudo make -C build/unix cleandirs
+        sudo make -C build/unix CC=x86_64-w64-mingw32-gcc WIN=1 package
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: "build/unix/toolshed-*.tgz"
+

--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -12,19 +12,26 @@ else
 INSTALLDIR	= /usr/local/bin
 DOCDIR		= /usr/local/share/toolshed
 endif
+APPS 		= ar2 os9 mamou cecb decb tocgen makewav dis68
+APPS		:= $(foreach item,$(APPS),$(item)/$(item)$(SUFEXE))
+
 DIRS		= libtoolshed libnative libcecb librbf libcoco libdecb libmisc libsys \
-		decb cecb os9 makewav tocgen cocofuse \
+		decb cecb os9 makewav tocgen \
 		dis68 mamou ar2 \
-		doc lst2cmt unittest
+		doc
+
+ifneq ($(WIN),)
+PACKAGENAME	= toolshed-win64-$(VERSION).tgz
+else
+DIRS		:= $(DIRS) cocofuse lst2cmt unittest
+endif
 
 all:
 	$(foreach dir, $(DIRS), (cd $(dir); $(MAKE));)
 
 install: all
 	$(INSTALL) -d $(INSTALLDIR) $(DOCDIR)
-	$(INSTALL) ar2/ar2 os9/os9 mamou/mamou cecb/cecb decb/decb \
-	    tocgen/tocgen makewav/makewav dis68/dis68 lst2cmt/lst2cmt $(INSTALLDIR)
-	-$(INSTALL) cocofuse/cocofuse $(INSTALLDIR)
+	$(INSTALL) $(APPS) $(INSTALLDIR)
 	$(INSTALL) -m 0644 doc/ToolShed.html $(DOCDIR)
 
 package: INSTALLDIR=toolshed-$(VERSION)
@@ -33,6 +40,8 @@ package: install
 	tar czvf $(PACKAGENAME) toolshed-$(VERSION)
 	rm -rf toolshed-$(VERSION)
 
-clean:
+cleandirs:
 	$(foreach dir, $(DIRS), (cd $(dir); $(MAKE) clean);)
+	
+clean: cleandirs
 	$(RM) $(PACKAGENAME)

--- a/build/unix/ar2/Makefile
+++ b/build/unix/ar2/Makefile
@@ -8,7 +8,7 @@ CFLAGS	+= -DSYSV
 BINARY	= ar2
 OBJS	= ar.o arsup.o lz1.o o2u.o
 
-$(BINARY):	$(OBJS)
+$(BINARY)$(SUFEXE):	$(OBJS)
 	$(CC) $(OBJS) -o $@ $(DEBUG)
 
 $(OBJS):

--- a/build/unix/cecb/Makefile
+++ b/build/unix/cecb/Makefile
@@ -6,7 +6,7 @@ vpath %.c ../../../cecb ../../../os9
 CFLAGS	+= -I../../../include -Wall
 LDFLAGS	+= -L../libtoolshed -L../libcoco -L../libcecb -L../libnative -L../librbf -L../libdecb -L../libmisc -L../libsys -ltoolshed -lcoco -ldecb -lcecb -lnative -lrbf -lmisc -lsys -lm
 
-cecb:	cecbbulkerase.o cecbdir.o cecbfstat.o cecb_main.o cecbcopy.o ../os9/os9dump.o ../decb/decblist.o
+cecb$(SUFEXE):	cecbbulkerase.o cecbdir.o cecbfstat.o cecb_main.o cecbcopy.o ../os9/os9dump.o ../decb/decblist.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:

--- a/build/unix/decb/Makefile
+++ b/build/unix/decb/Makefile
@@ -6,7 +6,7 @@ vpath %.c ../../../decb ../../../os9
 CFLAGS	+= -I../../../include -Wall
 LDFLAGS	+= -L../libtoolshed -L../libcoco -L../libnative -L../libcecb -L../librbf -L../libdecb -L../libmisc -L../libsys -ltoolshed -lcoco -lnative -lcecb -lrbf -ldecb -lmisc -lsys -lm
 
-decb:	decb_main.o decbattr.o decbcopy.o decbdir.o decbdskini.o decbfree.o decbfstat.o \
+decb$(SUFEXE):	decb_main.o decbattr.o decbcopy.o decbdir.o decbdskini.o decbfree.o decbfstat.o \
 	decbhdbconv.o decbkill.o decblist.o decbrename.o os9dump.o decbdsave.o os9dsave.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 

--- a/build/unix/dis68/Makefile
+++ b/build/unix/dis68/Makefile
@@ -3,7 +3,8 @@ include ../rules.mak
 
 vpath %.c ../../../dis68
 
-dis68: dis68.o disasm.o addmod.o symtbl.o
+dis68$(SUFEXE): dis68.o disasm.o addmod.o symtbl.o
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:
 	$(RM) *.o dis68 dis68.exe

--- a/build/unix/makewav/Makefile
+++ b/build/unix/makewav/Makefile
@@ -9,7 +9,7 @@ BINARY	= makewav
 OBJS	= makewav.o
 LIBS	= -lm
 
-$(BINARY):	$(OBJS)
+$(BINARY)$(SUFEXE):	$(OBJS)
 	$(CC) $(OBJS) $(LIBS) -o $@
 
 clean:

--- a/build/unix/mamou/Makefile
+++ b/build/unix/mamou/Makefile
@@ -7,7 +7,7 @@ DEBUG	= -g
 CFLAGS	+= -DLINUX -I../../../include $(DEBUG) -Wall
 LDFLAGS	+= -L../libcoco -L../libnative -L../libcecb -L../libdecb -L../librbf -L../libmisc -L../libsys -lcoco -lnative -ldecb -lcecb -lrbf -lmisc -lsys -lm $(DEBUG)
 
-mamou:		mamou_main.o evaluator.o pseudo.o h6309.o ffwd.o \
+mamou$(SUFEXE):		mamou_main.o evaluator.o pseudo.o h6309.o ffwd.o \
 		print.o util.o symbol_bucket.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 

--- a/build/unix/os9/Makefile
+++ b/build/unix/os9/Makefile
@@ -5,7 +5,7 @@ vpath %.c ../../../os9
 
 LDFLAGS	+= -L../libtoolshed -L../libcecb -L../libcoco -L../libnative -L../libdecb -L../libmisc -L../librbf -L../libsys -ltoolshed -lcoco -lnative -ldecb -lcecb -lmisc -lrbf -lsys -lm
 
-os9:	os9copy.o os9dsave.o os9gen.o os9modbust.o os9dcheck.o os9dump.o \
+os9$(SUFEXE):	os9copy.o os9dsave.o os9gen.o os9modbust.o os9dcheck.o os9dump.o \
 	os9id.o os9padrom.o os9_main.o os9del.o os9format.o os9ident.o \
 	os9rename.o os9attr.o os9deldir.o os9free.o os9list.o os9cmp.o \
 	os9dir.o os9fstat.o os9makdir.o

--- a/build/unix/rules.mak
+++ b/build/unix/rules.mak
@@ -13,6 +13,10 @@ AR		= $(CROSS)ar
 RANLIB		= $(CROSS)ranlib
 CC		= $(CROSS)cc
 
+ifneq ($(WIN),)
+SUFEXE		= .exe
+endif
+
 %.l: %.r
 	$(MERGE) $< > $@
 

--- a/build/unix/tocgen/Makefile
+++ b/build/unix/tocgen/Makefile
@@ -9,7 +9,7 @@ BINARY	= tocgen
 OBJS	= tocgen_main.o
 
 
-$(BINARY):	$(OBJS)
+$(BINARY)$(SUFEXE):	$(OBJS)
 	$(CC) $(OBJS) -o $@ $(LDFLAGS) $(DEBUG)
 
 $(OBJS):	Makefile


### PR DESCRIPTION
- add a 'Make Release' github action (manually triggered as needed) to compile the unix and window packages and attach them to a release for downloading.
- uses the unix makefiles to do both (with some minor changes) making the win32 makefiles somewhat redundant.
- to see example, see https://github.com/callsop/toolshed and 'Releases', click on the dummy release.