### PR TITLE
Format add interleave option

### DIFF
--- a/doc/ToolShed.md
+++ b/doc/ToolShed.md
@@ -548,6 +548,7 @@ This command is intended to work on the host file system only.
 <tr><td>-ds</td><td>double sided</td></tr>
 <tr><td>-tX</td><td>tracks (default = 35)</td></tr>
 <tr><td>-stX</td><td>sectors per track (default = 18)</td></tr>
+<tr><td>-iX</td><td>interleave (default = 3)</td></tr>
 <tr><td>-dr</td><td>format a Dragon disk</td></tr>
 </table>
 

--- a/include/os9path.h
+++ b/include/os9path.h
@@ -142,7 +142,7 @@ error_code _os9_delete_directory(char *pathlist);
 error_code _os9_rename( char *pathlist, char *new_name );
 error_code _os9_rename_ex(char *pathlist, char *new_name, os9_dir_entry *dentry);
 error_code _os9_close(os9_path_id);
-error_code _os9_format(char *pathname, int os968k, int tracks, int sectorsPerTrack, int sectorsTrack0, int heads, int sectorSize, int *clusterSize, char *diskName, int sectorAllocationSize, int tpi, int density, int formatEntire, int isDragon, int isHDD, unsigned int *totalSectors, unsigned int *totalBytes);
+error_code _os9_format(char *pathname, int os968k, int tracks, int sectorsPerTrack, int sectorsTrack0, int heads, int sectorSize, int *clusterSize, char *diskName, int sectorAllocationSize, int tpi, int density, int formatEntire, int isDragon, int isHDD, int interleave, unsigned int *totalSectors, unsigned int *totalBytes);
 
 /* gs.c */
 error_code _os9_gs_attr(os9_path_id, int *);

--- a/librbf/librbfformat.c
+++ b/librbf/librbfformat.c
@@ -20,7 +20,7 @@ error_code _os9_format(char *pathname, int os968k, int tracks,
 			   int heads, int sectorSize,
 		       int *clusterSize, char *diskName,
 		       int sectorAllocationSize, int tpi, int density,
-		       int formatEntire, int isDragon, int isHDD,
+		       int formatEntire, int isDragon, int isHDD, int interleave,
 		       unsigned int *totalSectors, unsigned int *totalBytes)
 {
 	error_code ec = 0;
@@ -183,7 +183,7 @@ error_code _os9_format(char *pathname, int os968k, int tracks,
 	_int2(sectorsPerTrack, s0.pd_sct);
 	_int2(sectorsTrack0, s0.pd_t0s);
 
-	_int1(3, s0.pd_ilv);
+	_int1(interleave, s0.pd_ilv);
 	_int1(sectorAllocationSize, s0.pd_sas);
 
 	if (os968k == 1)

--- a/os9/os9format.c
+++ b/os9/os9format.c
@@ -35,6 +35,7 @@ static char const *const helpMessage[] = {
 	"     -tX  = tracks (default = 35)\n",
 	"     -stX = sectors per track (default = 18)\n",
 	"     -szX = sectors for track 0 (default = 18)\n",
+	"     -iX  = interleave (default = 3)\n",
 	"     -dr  = format a Dragon disk\n",
 	" Hard Drive Options:\n",
 	"     -lX  = number of logical sectors (floppy options ignored)\n",
@@ -42,6 +43,7 @@ static char const *const helpMessage[] = {
 };
 
 #define DEF_SECTORS_TRACK	18
+#define DEF_INTERLEAVE		 3
 
 int os9format(int argc, char **argv)
 {
@@ -60,6 +62,7 @@ int os9format(int argc, char **argv)
 	int quiet = 0;		/* assume chatter */
 	int clusterSize = 0;	/* assume no cluster size */
 	int sectorAllocationSize = 8;	/* default */
+	int interleave = DEF_INTERLEAVE;
 	int os968k = 0;		/* assume OS-9/6809 LSN0 */
 	int formatEntire = 0;	/* format entire disk image */
 	int isDragon = 0;	/* format disk as Dragon, with reserved boot sectors at begining */
@@ -201,6 +204,12 @@ int os9format(int argc, char **argv)
 						p++;
 					break;
 
+				case 'i':	/* interleave */
+					interleave = atoi(p + 1);
+					while (*(p + 1) != '\0')
+						p++;
+					break;
+
 				case 't':	/* tracks */
 					tracks = atoi(p + 1);
 					while (*(p + 1) != '\0')
@@ -295,8 +304,8 @@ int os9format(int argc, char **argv)
 					    heads, bytesPerSector, &clusterSize,
 					    diskName, sectorAllocationSize,
 					    tpi, density, formatEntire,
-					    isDragon, isHDD, &totalSectors,
-					    &totalBytes);
+					    isDragon, isHDD, interleave,
+					    &totalSectors, &totalBytes);
 
 			if (ec == 0)
 			{

--- a/unittest/librbftest.c
+++ b/unittest/librbftest.c
@@ -18,14 +18,14 @@ void test_os9_format()
 	int clusterSize = 0;
 
 	ec = _os9_format("test.dsk", 0, 35, 18, 18, 1, 256, &clusterSize, "Test Disk", 8, 8,
-			 1, 1, 0, 0, &totalSectors, &totalBytes);
+			 1, 1, 0, 0, 3, &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
 	ASSERT_EQUALS(1, clusterSize);
 
 	// test format of a non-existent disk image with a disk name that is way too long
 	ec = _os9_format("test.dsk", 0, 35, 18, 18, 1, 256, &clusterSize,
 			 "Test Disk with filename that is way too long for the field",
-			 8, 8, 1, 1, 0, 0, &totalSectors, &totalBytes);
+			 8, 8, 1, 1, 0, 0, 3, &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
 
 
@@ -60,7 +60,7 @@ void test_os9_format()
 	ec = _os9_format("test.dsk", /*68k=*/0,
 			/*tracks=*/125, /*sPT=*/4, /*sT0=*/4, /*heads=*/130, /*sSize=*/256, &clusterSize,
 			 "HD-Test",
-			 /*sas=*/8, /*tpi=*/0, /*density=*/0, /*fE=*/1, /*isD=*/0, /*isHDD=*/1,
+			 /*sas=*/8, /*tpi=*/0, /*density=*/0, /*fE=*/1, /*isD=*/0, /*isHDD=*/1, /*interleave-*/3,
 			 &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
 	ASSERT_EQUALS(65000, totalSectors);
@@ -287,7 +287,7 @@ void test_os9_file_allocation()
 	unsigned int totalSectors, totalBytes;
 	int clusterSize = 0;
 	ec = _os9_format("test_alloc.dsk", 0, 80, 18, 18, 2, 256, &clusterSize, "Test Allo", 8, 8,
-			 1, 1, 0, 0, &totalSectors, &totalBytes);
+			 1, 1, 0, 0, 3, &totalSectors, &totalBytes);
 
 	/* Record free space */
 	char dname[64];

--- a/unittest/libtoolshedtest.c
+++ b/unittest/libtoolshedtest.c
@@ -118,7 +118,7 @@ void create_disk(char *name)
 	unsigned int totalSectors, totalBytes;
 	int clusterSize = 0;
 	ec = _os9_format(name, 0, 80, 18, 18, 2, 256, &clusterSize, "Test LTS", 8, 8,
-			 1, 1, 0, 0, &totalSectors, &totalBytes);
+			 1, 1, 0, 0, 3, &totalSectors, &totalBytes);
 	ASSERT_EQUALS(0, ec);
 }
 


### PR DESCRIPTION
Added -iX option to specify interleave (adding to -[?h] output and summary if -q isn't used). The default value is the one it currently uses, i.e. 3, for backwards compatibility.