### PR TITLE
Revise the structure of DD.OPT to work both for 6809 and 68000.

### DIFF
--- a/doc/ToolShed.md
+++ b/doc/ToolShed.md
@@ -645,7 +645,7 @@ This command will work on RBF disk images only.
 
 #### Description
 
-The gen command gives a disk image the ability to become a bootable disk for a CoCo or Dragon machine.
+The gen command gives a disk image the ability to become a bootable disk for a CoCo, Dragon or MM/1.
 
 ---
 

--- a/include/os9path.h
+++ b/include/os9path.h
@@ -62,30 +62,58 @@ typedef struct
 		dd_bt[3],
 		dd_bsz[2],
 		dd_dat[5],
-		dd_nam[32],
-		/* These used to be called dd_opt[32] */
-			pd_dtp[1],
-			pd_drv[1],
-			pd_stp[1],
-			pd_typ[1],
-			pd_dns[1],
-			pd_cyl[2],
-			pd_sid[1],
-			pd_vfy[1],
-			pd_sct[2],
-			pd_t0s[2],
-			pd_ilv[1],
-			pd_sas[1],
-			pd_tfm[1],
-			pd_exten[2],
-			pd_stoff[1],
-			pd_att[1],
-			pd_fd[3],
-			pd_dfd[3],
-			pd_dcp[4],
-			pd_dvt[2],
-		/* These are used by OS-9/68K */
-		dd_res1[1],
+		dd_nam[32];
+	/* These used to be called dd_opt[32] */
+	union
+	{
+		struct
+		{
+			u_char	pd_dtp[1],
+				pd_drv[1],
+				pd_stp[1],
+				pd_typ[1],
+				pd_dns[1],
+				pd_cyl[2],
+				pd_sid[1],
+				pd_vfy[1],
+				pd_sct[2],
+				pd_t0s[2],
+				pd_ilv[1],
+				pd_sas[1],
+				pd_tfm[1],
+				pd_exten[2],
+				pd_stoff[1],
+				pd_att[1],
+				pd_fd[3],
+				pd_dfd[3],
+				pd_dcp[4],
+				pd_dvt[2];
+		} m6809;
+		struct {
+			u_char	pd_dtp[1],
+				pd_drv[1],
+				pd_stp[1],
+				pd_typ[1],
+				pd_dns[1],
+				pd_res1[1],
+				pd_cyl[2],
+				pd_sid[1],
+				pd_vfy[1],
+				pd_sct[2],
+				pd_t0s[2],
+				pd_sas[2],
+				pd_ilv[1],
+				pd_tfm[1],
+				pd_toffs[1],
+				pd_soffs[1],
+				pd_ssize[2],
+				pd_cntl[2],
+				pd_trys[1];
+		} m68k;
+	} dd_opt;
+
+	/* These are used by OS-9/68K */
+	u_char	dd_res2[1],
 		dd_sync[4],		/* CRUZ */
 		dd_maplsn[4],
 		dd_lsnsize[2],

--- a/librbf/librbfbitmap.c
+++ b/librbf/librbfbitmap.c
@@ -129,21 +129,25 @@ int _os9_getfreebit(u_char * bitmap, int total_sectors)
 
 error_code _os9_getSASSegment(os9_path_id path, int *cluster, int *size)
 {
-	unsigned int pd_sas = int1(path->lsn0->pd_sas);
+	int is_osk = (memcmp(path->lsn0->dd_sync, "Cruz", 4) == 0);
+
+	unsigned int pd_sas = is_osk ? int2(path->lsn0->dd_opt.m68k.pd_sas)
+				     : int1(path->lsn0->dd_opt.m6809.pd_sas);
+
 	unsigned int pd_tot = int3(path->lsn0->dd_tot);
 	u_int i, count;
 	u_int prev_free;
 
-
 	/* Sanity check pd_sas */
-
 	if (pd_sas < 1 || pd_sas > (pd_tot / 2))
 	{
 		pd_sas = 1;
 
-		_int1(pd_sas, path->lsn0->pd_sas);
+		if (is_osk)
+			_int2(pd_sas, path->lsn0->dd_opt.m68k.pd_sas);
+		else
+			_int1(pd_sas, path->lsn0->dd_opt.m6809.pd_sas);
 	}
-
 
 	/* Adjust pd_sas so that it is at least a multiple of the
 	 * cluster size

--- a/librbf/librbfopen.c
+++ b/librbf/librbfopen.c
@@ -930,6 +930,8 @@ static int term_bitmap(os9_path_id path)
  */
 static int init_lsn0(os9_path_id path)
 {
+	int is_osk;
+
 	/* 1. Allocate 256 bytes for LSN0. */
 
 	path->lsn0 = (lsn0_sect *) malloc(1 * 256);
@@ -948,6 +950,8 @@ static int init_lsn0(os9_path_id path)
 	/* 3. Read 256 byte LSN0. */
 
 	fread(path->lsn0, 1, 256, path->fd);
+
+	is_osk = (memcmp(path->lsn0->dd_sync, "Cruz", 4) == 0);
 
 
 	/* 4. Compute bytes per sector from LSN0's lsnsize field. */
@@ -972,7 +976,8 @@ static int init_lsn0(os9_path_id path)
 	/* 5. Determine proper sectors per track */
 
 	path->spt = int2(path->lsn0->dd_spt);
-	path->t0s = int2(path->lsn0->pd_t0s);
+	path->t0s = int2(is_osk ? path->lsn0->dd_opt.m6809.pd_t0s
+				: path->lsn0->dd_opt.m6809.pd_t0s);
 
 	if (path->t0s == 0)
 	{

--- a/os9/os9gen.c
+++ b/os9/os9gen.c
@@ -174,6 +174,8 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 		int startlsn;
 		error_code ec;
 		char boottrack[256 * 18];
+		u_char *pd_sct, *pd_cyl, *pd_sid, *pd_typ;
+		int is_osk;
 
 
 		/* 1. Open the device raw and read LSB0 */
@@ -202,9 +204,26 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 
 		clusterSize = int2(LSN0.dd_bit);
 
+		is_osk = (memcmp(LSN0.dd_sync, "Cruz", 4) == 0);
+
+		if (is_osk != 0)
+		{
+			pd_sct = LSN0.dd_opt.m68k.pd_sct;
+			pd_cyl = LSN0.dd_opt.m68k.pd_cyl;
+			pd_sid = LSN0.dd_opt.m68k.pd_sid;
+			pd_typ = LSN0.dd_opt.m68k.pd_typ;
+		}
+		else
+		{
+			pd_sct = LSN0.dd_opt.m6809.pd_sct;
+			pd_cyl = LSN0.dd_opt.m6809.pd_cyl;
+			pd_sid = LSN0.dd_opt.m6809.pd_sid;
+			pd_typ = LSN0.dd_opt.m6809.pd_typ;
+		}
+
 		/*  Diagnostic output */
 
-		/* printf("Sectors per track: %d, Heads: %d, Disk Type: %d, Total Sectors: %d \n", int2(LSN0.pd_sct), int1(LSN0.pd_sid), int1(LSN0.pd_typ), int3(LSN0.dd_tot)); */
+		/* printf("Sectors per track: %d, Heads: %d, Disk Type: %d, Total Sectors: %d \n", int2(pd_sct), int1(pd_sid), int1(pd_typ), int3(LSN0.dd_tot)); */
 
 		/* 2. Determine startlsn based on single or double-sided device */
 
@@ -216,12 +235,12 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 		{
 			printf("Dragon boottrack selected: ");
 			/* Check to make sure the disk image has minimum of 18 sectors per track */
-			if (int2(LSN0.pd_sct) < 18)
+			if (int2(pd_sct) < 18)
 			{
 				printf("\n");
 				fprintf(stderr,
 					"Error: minimum sectors per track of 18 required for DragonDOS, found %d\n",
-					int2(LSN0.pd_sct));
+					int2(pd_sct));
 				_os9_close(opath);
 				return (1);
 			}
@@ -239,36 +258,36 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 			{
 				/* Check to see if disk image is a HDD image if so set for default  */
 				/* startLSN of 612 for the boottrack for use with CoCoSDC and DriveWire HDD images */
-				if (int1(LSN0.pd_typ) == 0x80)
+				if (int1(pd_typ) == 0x80)
 				{
 					startlsn = 612;
 				}
 				else
 				{
 					/* Check to make sure the disk image has minimum of 18 sectors per track */
-					if (int2(LSN0.pd_sct) < 18)
+					if (int2(pd_sct) < 18)
 					{
 						printf("\n");
 						fprintf(stderr,
 							"Error: minimum sectors per track of 18 required for Disk Basic, found %d\n",
-							int2(LSN0.pd_sct));
+							int2(pd_sct));
 						_os9_close(opath);
 						return (1);
 					}
 					/* Check to make sure the disk image has minimum of 35 tracks */
-					if (int2(LSN0.pd_cyl) < 35)
+					if (int2(pd_cyl) < 35)
 					{
 						printf("\n");
 						fprintf(stderr,
 							"Error: minimum number of tracks required for Disk Basic is 35, found %d\n",
-							int2(LSN0.pd_cyl));
+							int2(pd_cyl));
 						_os9_close(opath);
 						return (1);
 					}
 					/* Use real floppy disk geometry to figure out real startLSN for boottrack */
 					startlsn =
-						34 * int2(LSN0.pd_sct) *
-						int1(LSN0.pd_sid);
+						34 * int2(pd_sct) *
+						int1(pd_sid);
 				}
 			}
 		}

--- a/os9/os9id.c
+++ b/os9/os9id.c
@@ -110,6 +110,7 @@ static int do_id(char **argv, char *p)
 		char *p;
 		lsn0_sect buffer;
 		u_int size = sizeof(buffer);
+		int is_osk;
 
 		/* read LSN0 */
 		ec = _os9_read(path, &buffer, &size);
@@ -180,7 +181,8 @@ static int do_id(char **argv, char *p)
 		       OS9StringToCString((u_char *) p));
 
 		/* Attempt to identify an OS-9/68K os9 formatted disk image */
-		if (int4(buffer.dd_sync) == 0x4372757A)
+		is_osk = (int4(buffer.dd_sync) == 0x4372757A);
+		if (is_osk)
 		{
 			printf("  Sync Bytes      :   $4372757A (CRUZ)\n");
 			printf("  Bitmap Sector   :   %d\n",
@@ -190,6 +192,8 @@ static int do_id(char **argv, char *p)
 		}
 		{
 			int bytesPerSector = 256;
+			u_char *pd_t0s = is_osk ? buffer.dd_opt.m68k.pd_t0s
+						: buffer.dd_opt.m6809.pd_t0s;
 
 			if (int1(buffer.dd_lsnsize) > 0)
 			{
@@ -197,7 +201,7 @@ static int do_id(char **argv, char *p)
 					int1(buffer.dd_lsnsize) * 256;
 			}
 			printf("  Bytes/Sector    :   %d\n", bytesPerSector);
-			printf("  Sectors Track 0 :   %d\n", int2(buffer.pd_t0s));
+			printf("  Sectors Track 0 :   %d\n", int2(pd_t0s));
 		}
 	}
 


### PR DESCRIPTION
The motivation was to let os9 format create a disk image with LSN 0 matching that of the image of an actual MM/1 bootable floppy, but of course the effects percolate into other code using DD.OPT.

Things of note:

- The LSN0 "sync code" (ASCII for "Cruz") dates from OS-9/68000 v2.2, which predates any of the "CoCo 4" computers and predates CD-i. I'm pretty sure early OS-9/68000 RBF format matched 6809--I hand-translated a hard drive device driver from 6809 assembler to 68000 to see whether a Smoke Signal Broadcasting Chieftain with a then-new 68008 CPU card could run OSK and use a hard drive created and used under OS-9/6809, and it worked as far as we could tell. Perhaps `is_osk` is better called `isnt_6809`?
- There may well be MM/1-specific values wired in as things stand now, just as there are some CoCo/Dragon-specific values wired in. `os9 format` might need options for more settings.
- I used a Python script for dumping LSN 0 that I wrote with ChatGPT help to find out why the images I formatted weren't consistent with an actual MM/1 bootable floppy. It might be worth making `os9 id` display those additional values for sufficiently recent OS-9/68000 disk images.
- This is an attempt to make a minimal change, but ultimately shouldn't `_os9_getSASSegment()` not bother with a 6x09 RBF limitation when working on a (sufficiently new) OS-9/68000 RBF disk image?