### PR TITLE
Change DECB COPY to stream load data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build/unix/unittest/libtoolshedtest
 build/unix/unittest/os9commandtest
 build/unix/unittest/test.dsk
 build/unix/unittest/test_alloc.dsk
+build/unix/unittest/empty_file
 
 # Language file for BBEdit
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,27 @@
 *.wav
 filldisk.dsk
 
+# Ignore built files
+build/unix/ar2/ar2
+build/unix/cecb/cecb
+build/unix/cocofuse/cocofuse
+build/unix/decb/decb
+build/unix/dis68/dis68
+build/unix/doc/ToolShed.html
+build/unix/lst2cmt/lst2cmt
+build/unix/makewav/makewav
+build/unix/mamou/mamou
+build/unix/os9/os9
+build/unix/tocgen/tocgen
+build/unix/unittest/decbcommandtest
+build/unix/unittest/libcecbtest
+build/unix/unittest/libdecbtest
+build/unix/unittest/librbftest
+build/unix/unittest/libtoolshedtest
+build/unix/unittest/os9commandtest
+build/unix/unittest/test.dsk
+build/unix/unittest/test_alloc.dsk
+
 # Language file for BBEdit
 compile_commands.json
 .cache/*

--- a/build/unix/unittest/Makefile
+++ b/build/unix/unittest/Makefile
@@ -21,7 +21,8 @@ TEST_LIBS = \
     ../libsys/libsys.a
 
 
-TESTS = librbftest libdecbtest libcecbtest libtoolshedtest os9commandtest
+TESTS = librbftest libdecbtest libcecbtest libtoolshedtest os9commandtest \
+	decbcommandtest
 $(TESTS): $(TEST_LIBS)
 
 testall: $(TESTS)
@@ -31,6 +32,7 @@ ifeq (,$(NOTEST))
 	./libcecbtest
 	./libtoolshedtest
 	./os9commandtest
+	./decbcommandtest
 endif
 
 clean:

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -13,10 +13,6 @@
 #define YES 1
 #define NO 0
 
-/* globals */
-//static u_int buffer_size = 32768;
-//static char *buffer;
-
 static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			       int tokTranslate, int binary_concat,
 			       int rewrite, int file_type, int data_type);
@@ -287,6 +283,8 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 	int mode = FAM_NOCREATE | FAM_WRITE;
 	unsigned char *buffer = NULL;
 	char *translation_buffer;
+	u_int buffer_capacity;
+	u_int bytes_read_total;
 	u_int new_translation_size;
 	u_int buffer_size;
 	coco_file_stat fstat;
@@ -322,8 +320,57 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		return ec;
 	}
 
-
 	ec = _coco_gs_size(path, &buffer_size);
+
+	/*
+	 * Some special files (e.g. Linux /proc files) report st_size == 0
+	 * via fstat() even though they contain data.  When the source is a
+	 * native path and the reported size is 0, fall back to reading the
+	 * file in chunks until we hit EOF so we capture the actual content.
+	 */
+	if (buffer_size == 0 && path->type == NATIVE)
+	{
+		const u_int CHUNK = 65536;
+		u_int chunk_read;
+
+		buffer_capacity = CHUNK;
+		buffer = malloc(buffer_capacity);
+		if (buffer == NULL)
+		{
+			_coco_close(path);
+			_coco_close(destpath);
+			return -1;
+		}
+
+		bytes_read_total = 0;
+		while (1)
+		{
+			chunk_read = buffer_capacity - bytes_read_total;
+			ec = _coco_read(path, buffer + bytes_read_total, &chunk_read);
+			bytes_read_total += chunk_read;
+
+			if (ec != 0)   /* EOS_EOF or real error */
+				break;
+
+			/* Grow buffer if we filled it and haven't hit EOF yet */
+			if (bytes_read_total == buffer_capacity)
+			{
+				buffer_capacity *= 2;
+				unsigned char *tmp = realloc(buffer, buffer_capacity);
+				if (tmp == NULL)
+				{
+					free(buffer);
+					_coco_close(path);
+					_coco_close(destpath);
+					return -1;
+				}
+				buffer = tmp;
+			}
+		}
+		/* Treat EOF as success; reset ec */
+		ec = 0;
+		buffer_size = bytes_read_total;
+	}
 
 	if (buffer_size > 0)
 	{

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -454,11 +454,11 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 				/* source is native, destination is coco */
 
 				NativeToDECB((char *) buffer, buffer_size,
-						 &translation_buffer,
-						 &new_translation_size);
+						&translation_buffer,
+						&new_translation_size);
 
 				ec = _coco_write(destpath, translation_buffer,
-						 &new_translation_size);
+						&new_translation_size);
 
 				free(translation_buffer);
 			}
@@ -468,10 +468,10 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 				/* source is coco, destination is native */
 
 				DECBToNative((char *) buffer, buffer_size,
-						 &translation_buffer,
-						 &new_translation_size);
+						&translation_buffer,
+						&new_translation_size);
 				ec = _coco_write(destpath, translation_buffer,
-						 &new_translation_size);
+						&new_translation_size);
 
 				free(translation_buffer);
 			}

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -324,7 +324,7 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 
 	buffer_capacity = CHUNK;
 	buffer = malloc(buffer_capacity);
-	
+
 	if (buffer == NULL)
 	{
 		_coco_close(path);
@@ -333,7 +333,7 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 	}
 
 	bytes_read_total = 0;
-	
+
 	while (1)
 	{
 		chunk_read = buffer_capacity - bytes_read_total;
@@ -361,21 +361,21 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 
 	if (ec != EOS_EOF)
 		return ec;
-		
+
 	ec = 0;
 	buffer_size = bytes_read_total;
-	
+
 	if (buffer_size > 0)
 	{
 		if (binary_concat == 1)
 		{
 			u_char *binconcat_buffer;
 			u_int binconcat_size;
-	
+
 			ec = _decb_binconcat(buffer, buffer_size,
 						 &binconcat_buffer,
 						 &binconcat_size);
-	
+
 			if (ec == 0)
 			{
 				free(buffer);
@@ -385,26 +385,26 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			else
 				return -1;
 		}
-	
+
 		if (tokTranslate == 1)
 		{
 			if (buffer[0] == 0xff)
 			{
 				u_char *detokenize_buffer = NULL;
 				u_int detokenize_size;
-	
+
 				/* File is already a tokenized BASIC file, de-tokenize it */
 				ec = _decb_detoken(buffer, buffer_size,
 						   (char **)
 						   &detokenize_buffer,
 						   &detokenize_size);
-	
+
 				if (ec == 0)
 				{
 					free(buffer);
 					buffer = detokenize_buffer;
 					buffer_size = detokenize_size;
-	
+
 					file_type = 0;
 					data_type = 0xff;
 				}
@@ -419,24 +419,24 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			{
 				unsigned char *entokenize_buffer = NULL;
 				u_int entokenize_size;
-	
+
 				/* Tokenized file */
 				ec = _decb_entoken(buffer, buffer_size,
 						   &entokenize_buffer,
 						   &entokenize_size,
 						   destpath->type == DECB);
-	
+
 				if (ec == 0)
 				{
 					free(buffer);
 					buffer = entokenize_buffer;
 					buffer_size = entokenize_size;
-	
+
 					file_type = 0;
 					data_type = 0;
-	
+
 					eolTranslate = 0;
-	
+
 				}
 				else
 				{
@@ -446,100 +446,100 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 				}
 			}
 		}
-	
+
 		if (eolTranslate == 1)
 		{
 			if (path->type == NATIVE && destpath->type != NATIVE)
 			{
 				/* source is native, destination is coco */
-	
+
 				NativeToDECB((char *) buffer, buffer_size,
 						 &translation_buffer,
 						 &new_translation_size);
-	
+
 				ec = _coco_write(destpath, translation_buffer,
 						 &new_translation_size);
-	
+
 				free(translation_buffer);
 			}
 			else if (path->type != NATIVE
 				 && destpath->type == NATIVE)
 			{
 				/* source is coco, destination is native */
-	
+
 				DECBToNative((char *) buffer, buffer_size,
 						 &translation_buffer,
 						 &new_translation_size);
 				ec = _coco_write(destpath, translation_buffer,
 						 &new_translation_size);
-	
+
 				free(translation_buffer);
 			}
 		}
 		else
 		{
 			/* One-to-one writing of the data -- no translation needed. */
-	
+
 			ec = _coco_write(destpath, buffer, &buffer_size);
 		}
-	
+
 		if (ec == EOS_DF)
 		{
 			/* Delete file, and return disk full */
 			_coco_close(destpath);
-			
+
 			ec = _coco_delete(dstfile);
-			
+
 			if( ec != 0 )
 			{
 				fprintf(stderr, "File write failed, then file delete failed.\n");
 			}
-			
+
 			return EOS_DF;
 		}
-		
+
 		if (ec != 0)
 		{
 			return ec;
 		}
-	
-	
+
+
 		/* Copy meta data from file descriptor of source to destination */
-	
+
 		{
 			coco_file_stat fd;
-	
-	
+
+
 			_coco_gs_fd(path, &fd);
-	
+
 			_coco_ss_fd(destpath, &fd);
 		}
-	
-	
+
+
 		/* Special -- if this is a DECB file we wrote to, set passed file type and data type. */
-	
+
 		{
 			_path_type t;
-	
+
 			_coco_gs_pathtype(destpath, &t);
-	
+
 			if (t == DECB)
 			{
 				decb_file_stat f;
-	
-	
+
+
 				_decb_gs_fd(destpath->path.decb, &f);
-	
+
 				if (file_type >= 0)
 				{
 					f.file_type = file_type;
 				}
-	
+
 				if (data_type >= 0)
 				{
 					f.data_type = data_type;
 				}
-	
+
 				_decb_ss_fd(destpath->path.decb, &f);
 			}
 		}

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -371,8 +371,7 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		ec = 0;
 		buffer_size = bytes_read_total;
 	}
-
-	if (buffer_size > 0)
+	else if (buffer_size > 0)
 	{
 		buffer = malloc(buffer_size);
 
@@ -387,16 +386,19 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		{
 			return -1;
 		}
-
+	}
+	
+	if (buffer_size > 0)
+	{
 		if (binary_concat == 1)
 		{
 			u_char *binconcat_buffer;
 			u_int binconcat_size;
-
+	
 			ec = _decb_binconcat(buffer, buffer_size,
-					     &binconcat_buffer,
-					     &binconcat_size);
-
+						 &binconcat_buffer,
+						 &binconcat_size);
+	
 			if (ec == 0)
 			{
 				free(buffer);
@@ -406,26 +408,26 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			else
 				return -1;
 		}
-
+	
 		if (tokTranslate == 1)
 		{
 			if (buffer[0] == 0xff)
 			{
 				u_char *detokenize_buffer = NULL;
 				u_int detokenize_size;
-
+	
 				/* File is already a tokenized BASIC file, de-tokenize it */
 				ec = _decb_detoken(buffer, buffer_size,
 						   (char **)
 						   &detokenize_buffer,
 						   &detokenize_size);
-
+	
 				if (ec == 0)
 				{
 					free(buffer);
 					buffer = detokenize_buffer;
 					buffer_size = detokenize_size;
-
+	
 					file_type = 0;
 					data_type = 0xff;
 				}
@@ -440,24 +442,24 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			{
 				unsigned char *entokenize_buffer = NULL;
 				u_int entokenize_size;
-
+	
 				/* Tokenized file */
 				ec = _decb_entoken(buffer, buffer_size,
 						   &entokenize_buffer,
 						   &entokenize_size,
 						   destpath->type == DECB);
-
+	
 				if (ec == 0)
 				{
 					free(buffer);
 					buffer = entokenize_buffer;
 					buffer_size = entokenize_size;
-
+	
 					file_type = 0;
 					data_type = 0;
-
+	
 					eolTranslate = 0;
-
+	
 				}
 				else
 				{
@@ -467,43 +469,43 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 				}
 			}
 		}
-
+	
 		if (eolTranslate == 1)
 		{
 			if (path->type == NATIVE && destpath->type != NATIVE)
 			{
 				/* source is native, destination is coco */
-
+	
 				NativeToDECB((char *) buffer, buffer_size,
-					     &translation_buffer,
-					     &new_translation_size);
-
+						 &translation_buffer,
+						 &new_translation_size);
+	
 				ec = _coco_write(destpath, translation_buffer,
 						 &new_translation_size);
-
+	
 				free(translation_buffer);
 			}
 			else if (path->type != NATIVE
 				 && destpath->type == NATIVE)
 			{
 				/* source is coco, destination is native */
-
+	
 				DECBToNative((char *) buffer, buffer_size,
-					     &translation_buffer,
-					     &new_translation_size);
+						 &translation_buffer,
+						 &new_translation_size);
 				ec = _coco_write(destpath, translation_buffer,
 						 &new_translation_size);
-
+	
 				free(translation_buffer);
 			}
 		}
 		else
 		{
 			/* One-to-one writing of the data -- no translation needed. */
-
+	
 			ec = _coco_write(destpath, buffer, &buffer_size);
 		}
-
+	
 		if (ec == EOS_DF)
 		{
 			/* Delete file, and return disk full */
@@ -523,44 +525,44 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		{
 			return ec;
 		}
-
-
+	
+	
 		/* Copy meta data from file descriptor of source to destination */
-
+	
 		{
 			coco_file_stat fd;
-
-
+	
+	
 			_coco_gs_fd(path, &fd);
-
+	
 			_coco_ss_fd(destpath, &fd);
 		}
-
-
+	
+	
 		/* Special -- if this is a DECB file we wrote to, set passed file type and data type. */
-
+	
 		{
 			_path_type t;
-
+	
 			_coco_gs_pathtype(destpath, &t);
-
+	
 			if (t == DECB)
 			{
 				decb_file_stat f;
-
-
+	
+	
 				_decb_gs_fd(destpath->path.decb, &f);
-
+	
 				if (file_type >= 0)
 				{
 					f.file_type = file_type;
 				}
-
+	
 				if (data_type >= 0)
 				{
 					f.data_type = data_type;
 				}
-
+	
 				_decb_ss_fd(destpath->path.decb, &f);
 			}
 		}

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -307,7 +307,6 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		return ec;
 	}
 
-
 	/* 3. Attempt to create the destfile. */
 
 	fstat.perms = FAP_READ | FAP_WRITE | FAP_PREAD;
@@ -320,73 +319,51 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		return ec;
 	}
 
-	ec = _coco_gs_size(path, &buffer_size);
+	const u_int CHUNK = 65536;
+	u_int chunk_read;
 
-	/*
-	 * Some special files (e.g. Linux /proc files) report st_size == 0
-	 * via fstat() even though they contain data.  When the source is a
-	 * native path and the reported size is 0, fall back to reading the
-	 * file in chunks until we hit EOF so we capture the actual content.
-	 */
-	if (buffer_size == 0 && path->type == NATIVE)
+	buffer_capacity = CHUNK;
+	buffer = malloc(buffer_capacity);
+	
+	if (buffer == NULL)
 	{
-		const u_int CHUNK = 65536;
-		u_int chunk_read;
+		_coco_close(path);
+		_coco_close(destpath);
+		return EOS_MF;
+	}
 
-		buffer_capacity = CHUNK;
-		buffer = malloc(buffer_capacity);
-		if (buffer == NULL)
+	bytes_read_total = 0;
+	
+	while (1)
+	{
+		chunk_read = buffer_capacity - bytes_read_total;
+		ec = _coco_read(path, buffer + bytes_read_total, &chunk_read);
+		bytes_read_total += chunk_read;
+
+		if (ec != 0)   /* EOS_EOF or real error */
+			break;
+
+		/* Grow buffer if we filled it and haven't hit EOF yet */
+		if (bytes_read_total == buffer_capacity)
 		{
-			_coco_close(path);
-			_coco_close(destpath);
-			return -1;
-		}
-
-		bytes_read_total = 0;
-		while (1)
-		{
-			chunk_read = buffer_capacity - bytes_read_total;
-			ec = _coco_read(path, buffer + bytes_read_total, &chunk_read);
-			bytes_read_total += chunk_read;
-
-			if (ec != 0)   /* EOS_EOF or real error */
-				break;
-
-			/* Grow buffer if we filled it and haven't hit EOF yet */
-			if (bytes_read_total == buffer_capacity)
+			buffer_capacity *= 2;
+			unsigned char *tmp = realloc(buffer, buffer_capacity);
+			if (tmp == NULL)
 			{
-				buffer_capacity *= 2;
-				unsigned char *tmp = realloc(buffer, buffer_capacity);
-				if (tmp == NULL)
-				{
-					free(buffer);
-					_coco_close(path);
-					_coco_close(destpath);
-					return -1;
-				}
-				buffer = tmp;
+				free(buffer);
+				_coco_close(path);
+				_coco_close(destpath);
+				return EOS_MF;
 			}
-		}
-		/* Treat EOF as success; reset ec */
-		ec = 0;
-		buffer_size = bytes_read_total;
-	}
-	else if (buffer_size > 0)
-	{
-		buffer = malloc(buffer_size);
-
-		if (buffer == NULL)
-		{
-			return -1;
-		};
-
-		ec = _coco_read(path, buffer, &buffer_size);
-
-		if (ec != 0)
-		{
-			return -1;
+			buffer = tmp;
 		}
 	}
+
+	if (ec != EOS_EOF)
+		return ec;
+		
+	ec = 0;
+	buffer_size = bytes_read_total;
 	
 	if (buffer_size > 0)
 	{

--- a/unittest/decbcommandtest.c
+++ b/unittest/decbcommandtest.c
@@ -1,0 +1,38 @@
+/*
+ * ALWAYS BE TESTING!!!
+ *
+ * ALWAYS BE WRITING MORE TESTS!!!
+ *
+ * THIS WORK IS **NEVER** DONE!!!
+ */
+
+#include "tinytest.h"
+#include <toolshed.h>
+
+void test_decb_command_dskini()
+{
+	error_code ec;
+	native_path_id nativepath;
+	u_int size;
+
+	ec = system("../decb/decb dskini test.dsk > /dev/null 2>&1");
+	ASSERT_EQUALS(0, ec);
+	
+	ec = _native_open(&nativepath, "test.dsk", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_gs_size(nativepath, &size);	
+	ASSERT_EQUALS(0, ec);
+	ASSERT_EQUALS(35*18*256, size);
+
+	ec = _native_close(nativepath);
+	ASSERT_EQUALS(0, ec);
+}
+
+int main()
+{
+	remove("test.dsk");
+	RUN(test_decb_command_dskini);
+	
+	return TEST_REPORT();
+}

--- a/unittest/decbcommandtest.c
+++ b/unittest/decbcommandtest.c
@@ -29,10 +29,78 @@ void test_decb_command_dskini()
 	ASSERT_EQUALS(0, ec);
 }
 
+void test_decb_command_copy()
+{
+	error_code ec;
+	native_path_id nativepath;
+	coco_path_id cocopath;
+	u_int source_size, dest_size;
+
+ 	ec = system("../decb/decb copy does_not_exist test.dsk,DNE.TXT > /dev/null 2>&1");
+ 	ASSERT_EQUALS(1, WIFEXITED(ec));
+ 	ec = WEXITSTATUS(ec);
+	ASSERT_EQUALS(EOS_PNNF, ec);
+
+	/* Test a simple copy */
+	
+	ec = system("../decb/decb copy Makefile test.dsk,MAKEF.TXT > /dev/null 2>&1");
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_open(&nativepath, "Makefile", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_gs_size(nativepath, &source_size);	
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_close(nativepath);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _coco_open(&cocopath, "test.dsk,MAKEF.TXT", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _coco_gs_size(cocopath, &dest_size);	
+	ASSERT_EQUALS(0, ec);
+
+	ec = _coco_close(cocopath);
+	ASSERT_EQUALS(0, ec);
+
+	ASSERT_EQUALS(dest_size, source_size);
+
+	/* Test a copy of an empty file */
+	
+	remove("empty_file");
+	ec = system("touch empty_file > /dev/null 2>&1");
+	ASSERT_EQUALS(0, ec);
+
+	ec = system("../decb/decb copy empty_file test.dsk,EMPTY.TXT > /dev/null 2>&1");
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_open(&nativepath, "empty_file", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_gs_size(nativepath, &source_size);	
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_close(nativepath);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _coco_open(&cocopath, "test.dsk,EMPTY.TXT", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _coco_gs_size(cocopath, &dest_size);	
+	ASSERT_EQUALS(0, ec);
+
+	ec = _coco_close(cocopath);
+	ASSERT_EQUALS(0, ec);
+
+	ASSERT_EQUALS(dest_size, source_size);
+}
+
 int main()
 {
 	remove("test.dsk");
 	RUN(test_decb_command_dskini);
+	RUN(test_decb_command_copy);
 	
 	return TEST_REPORT();
 }

--- a/unittest/libdecbtest.c
+++ b/unittest/libdecbtest.c
@@ -75,7 +75,7 @@ void test_decb_create()
 	// test create of an extra long (illegal) filename with a subfolder on an existing disk image
 	// the root file is a directory when it isn't
 	ec = _decb_create(&p,
-			  "test.dsk,file_doesnt_exist_and_is_much_longer_than_rbf_limit_of_8_characters/and_this_is_an_even_longer_name_than_the_8_character_limit_in9_rbf_because_it_has_more_characters",
+			  "test.dsk,file_doesnt_exist_and_is_much_longer_than_decb_limit_of_8_characters/and_this_is_an_even_longer_name_than_the_8_character_limit_in9_rbf_because_it_has_more_characters",
 			  FAM_READ, 0, 1);
 	ASSERT_EQUALS(EOS_BPNAM, ec);
 	

--- a/unittest/librbftest.c
+++ b/unittest/librbftest.c
@@ -401,9 +401,6 @@ int main()
 	RUN(test_os9_ss_calls);
 	RUN(test_os9_gs_calls);
 	RUN(test_os9_file_allocation);
-
-	remove("test.dsk");
-	remove("test_alloc.dsk");
-
+	
 	return TEST_REPORT();
 }


### PR DESCRIPTION
As explained in issue #50 sometimes a file that is not zero bytes big returns zero with `fstat`. This PR will fix these rare situations.