### PR TITLE
Fix meta data copy when OS9 to Native.

### DIFF
--- a/libcoco/libcocogs.c
+++ b/libcoco/libcocogs.c
@@ -170,12 +170,15 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 		timepak.tm_year = os9_stat.fd_creat[0];
 		timepak.tm_mon = os9_stat.fd_creat[1] - 1;
 		timepak.tm_mday = os9_stat.fd_creat[2];
+		timepak.tm_isdst = -1; /* let mktime determine DST */
 		statbuf->create_time = mktime(&timepak);
+		memset(&timepak, 0, sizeof(timepak));
 		timepak.tm_year = os9_stat.fd_dat[0];
 		timepak.tm_mon = os9_stat.fd_dat[1] - 1;
 		timepak.tm_mday = os9_stat.fd_dat[2];
 		timepak.tm_hour = os9_stat.fd_dat[3];
 		timepak.tm_min = os9_stat.fd_dat[4];
+		timepak.tm_isdst = -1; /* let mktime determine DST */
 		statbuf->last_modified_time = mktime(&timepak);
 		break;
 

--- a/libcoco/libcocoss.c
+++ b/libcoco/libcocoss.c
@@ -93,6 +93,10 @@ error_code _coco_ss_fd(coco_path_id path, coco_file_stat * statbuf)
 #endif
 		native_stat.st_uid = statbuf->user_id;
 		native_stat.st_gid = statbuf->group_id;
+	/* Note: st_ctime (inode-change time) cannot be set by user-space
+	 * on POSIX systems -- the kernel updates it automatically.  Only
+	 * st_mtime (last-modified time) can be restored via utime()/utimes().
+	 * We propagate last_modified_time into st_mtime on all platforms. */
 #if defined(WIN32)
 		native_stat.st_ctime = statbuf->create_time;
 		native_stat.st_mtime = statbuf->last_modified_time;

--- a/libnative/libnativeopen.c
+++ b/libnative/libnativeopen.c
@@ -91,6 +91,9 @@ error_code _native_create(native_path_id * path, char *pathlist, int mode,
 		nativeMode = "wb";
 	}
 
+	strncpy((*path)->pathlist, pathlist, sizeof((*path)->pathlist) - 1);
+	(*path)->pathlist[sizeof((*path)->pathlist) - 1] = '\0';
+
 	(*path)->fd = fopen(pathlist, nativeMode);
 
 	if ((*path)->fd == NULL)
@@ -174,6 +177,9 @@ error_code _native_open(native_path_id * path, char *pathlist, int mode)
 	{
 		nativeMode = "b";
 	}
+
+	strncpy((*path)->pathlist, pathlist, sizeof((*path)->pathlist) - 1);
+	(*path)->pathlist[sizeof((*path)->pathlist) - 1] = '\0';
 
 	(*path)->fd = fopen(pathlist, nativeMode);
 

--- a/libnative/libnativess.c
+++ b/libnative/libnativess.c
@@ -42,27 +42,26 @@ error_code _native_ss_attr(native_path_id path, int perms)
 error_code _native_ss_fd(native_path_id path, struct stat *statbuf)
 {
 	error_code ec = 0;
-/* Removed a conditional; RG*/
 	struct utimbuf tbuff;
 
 
-/* Removed a conditional; RG*/
-	tbuff.actime = statbuf->st_ctime;
+	/* Use mtime for both access-time and modification-time.
+	 * POSIX does not allow applications to set st_ctime directly (it is
+	 * managed by the kernel), so we cannot meaningfully restore a "creation
+	 * time" here.  Setting actime to st_mtime keeps access-time in sync with
+	 * the modification-time that was read from the source file descriptor. */
+	tbuff.actime  = statbuf->st_mtime;
 	tbuff.modtime = statbuf->st_mtime;
 
 
 	/* 1. Update times. */
 
-/* Removed a conditional; RG*/
 	utime(path->pathlist, &tbuff);
-/* #endif */
 
 
 	/* 2. Update permissions. */
 
-/* Removed a conditional; RG */
 	chmod(path->pathlist, statbuf->st_mode);
-
 
 
 	return ec;

--- a/libtoolshed/toolshed.c
+++ b/libtoolshed/toolshed.c
@@ -461,10 +461,22 @@ error_code TSCopyFile(char *srcfile, char *dstfile, int eolTranslate,
 		fdesc.group_id = owner / 65536;
 	}
 
-	_coco_ss_fd(destpath, &fdesc);
-
 	_coco_close(path);
+
+	/* Close the dest file before setting metadata. fclose() flushes
+	 * buffered writes and causes the OS to update mtime, which would
+	 * overwrite any utime() call made before it. Instead, close first,
+	 * then reopen briefly just to apply the metadata (mtime, perms). */
 	_coco_close(destpath);
+
+	{
+		coco_path_id metapath;
+		if (_coco_open(&metapath, dstfile, FAM_READ | FAM_WRITE) == 0)
+		{
+			_coco_ss_fd(metapath, &fdesc);
+			_coco_close(metapath);
+		}
+	}
 
 
 	return ec;

--- a/unittest/os9commandtest.c
+++ b/unittest/os9commandtest.c
@@ -32,12 +32,54 @@ void test_os9_command_format()
 	ASSERT_EQUALS(0, ec);
 }
 
+void test_os9_command_copy_metadata()
+{
+    error_code ec;
+    struct stat native_stat;
+    os9_path_id os9path;
+    fd_stats os9_fstat;
+	int os9_fstat_size = sizeof(os9_fstat);
+    fd_stats converted_native_fstat = {0};
+
+    /* Create a file on the disk image with known content */
+    ec = _os9_create(&os9path, "test.dsk,meta.txt",
+                     FAM_READ | FAM_WRITE, FAP_READ | FAP_WRITE);
+    ASSERT_EQUALS(0, ec);
+    char *buf = "hello";
+    u_int size = strlen(buf);
+    ec = _os9_write(os9path, buf, &size);
+    ASSERT_EQUALS(0, ec);
+    ec = _os9_close(os9path);
+    ASSERT_EQUALS(0, ec);
+
+    /* Copy from OS9 image to native filesystem */
+    ec = system("../os9/os9 copy test.dsk,meta.txt meta_out.txt > /dev/null 2>&1");
+    ASSERT_EQUALS(0, ec);
+
+    /* Read the OS9 file's modification time */
+    ec = _os9_open(&os9path, "test.dsk,meta.txt", FAM_READ);
+    ASSERT_EQUALS(0, ec);
+    ec = _os9_gs_fd(os9path, os9_fstat_size, &os9_fstat);
+    ASSERT_EQUALS(0, ec);
+    ec = _os9_close(os9path);
+    ASSERT_EQUALS(0, ec);
+
+    /* Check that the native file's mtime matches the OS9 last_modified_time */
+    ec = stat("meta_out.txt", &native_stat);
+    ASSERT_EQUALS(0, ec);
+
+    UnixToOS9Time(native_stat.st_mtime, (char *) converted_native_fstat.fd_dat);
+
+	ASSERT_MEM_EQUALS(os9_fstat.fd_dat, converted_native_fstat.fd_dat, 5);
+	
+    remove("meta_out.txt");
+}
+
 int main()
 {
 	remove("test.dsk");
 	RUN(test_os9_command_format);
-
-	remove("test.dsk");
+	RUN(test_os9_command_copy_metadata);
 
 	return TEST_REPORT();
 }

--- a/unittest/os9commandtest.c
+++ b/unittest/os9commandtest.c
@@ -34,45 +34,64 @@ void test_os9_command_format()
 
 void test_os9_command_copy_metadata()
 {
-    error_code ec;
-    struct stat native_stat;
-    os9_path_id os9path;
-    fd_stats os9_fstat;
+	error_code ec;
+	struct stat native_stat;
+	os9_path_id os9path;
+	fd_stats os9_fstat;
 	int os9_fstat_size = sizeof(os9_fstat);
-    fd_stats converted_native_fstat = {0};
-
-    /* Create a file on the disk image with known content */
-    ec = _os9_create(&os9path, "test.dsk,meta.txt",
-                     FAM_READ | FAM_WRITE, FAP_READ | FAP_WRITE);
-    ASSERT_EQUALS(0, ec);
-    char *buf = "hello";
-    u_int size = strlen(buf);
-    ec = _os9_write(os9path, buf, &size);
-    ASSERT_EQUALS(0, ec);
-    ec = _os9_close(os9path);
-    ASSERT_EQUALS(0, ec);
-
-    /* Copy from OS9 image to native filesystem */
-    ec = system("../os9/os9 copy test.dsk,meta.txt meta_out.txt > /dev/null 2>&1");
-    ASSERT_EQUALS(0, ec);
-
-    /* Read the OS9 file's modification time */
-    ec = _os9_open(&os9path, "test.dsk,meta.txt", FAM_READ);
-    ASSERT_EQUALS(0, ec);
-    ec = _os9_gs_fd(os9path, os9_fstat_size, &os9_fstat);
-    ASSERT_EQUALS(0, ec);
-    ec = _os9_close(os9path);
-    ASSERT_EQUALS(0, ec);
-
-    /* Check that the native file's mtime matches the OS9 last_modified_time */
-    ec = stat("meta_out.txt", &native_stat);
-    ASSERT_EQUALS(0, ec);
-
-    UnixToOS9Time(native_stat.st_mtime, (char *) converted_native_fstat.fd_dat);
-
-	ASSERT_MEM_EQUALS(os9_fstat.fd_dat, converted_native_fstat.fd_dat, 5);
+	fd_stats converted_native_fstat = {0};
+ 
+	/* Create a file on the disk image with known content */
+	ec = _os9_create(&os9path, "test.dsk,meta.txt",
+	                 FAM_READ | FAM_WRITE, FAP_READ | FAP_WRITE);
+	ASSERT_EQUALS(0, ec);
+	char *buf = "hello";
+	u_int size = strlen(buf);
+	ec = _os9_write(os9path, buf, &size);
+	ASSERT_EQUALS(0, ec);
+	ec = _os9_close(os9path);
+	ASSERT_EQUALS(0, ec);
+ 
+	/* Set the OS9 file's modification date to a fixed date in the 1980s:
+	 * January 15, 1987 at 10:30 (OS9 fd_dat: year, month, day, hour, min).
+	 * January is chosen to avoid DST ambiguity in the mktime round-trip. */
+	ec = _os9_open(&os9path, "test.dsk,meta.txt", FAM_READ | FAM_WRITE);
+	ASSERT_EQUALS(0, ec);
+	ec = _os9_gs_fd(os9path, os9_fstat_size, &os9_fstat);
+	ASSERT_EQUALS(0, ec);
+	os9_fstat.fd_dat[0] = 87;  /* year: 1987 (years since 1900) */
+	os9_fstat.fd_dat[1] = 1;   /* month: January */
+	os9_fstat.fd_dat[2] = 15;  /* day */
+	os9_fstat.fd_dat[3] = 10;  /* hour */
+	os9_fstat.fd_dat[4] = 30;  /* minute */
+	ec = _os9_ss_fd(os9path, os9_fstat_size, &os9_fstat);
+	ASSERT_EQUALS(0, ec);
+	ec = _os9_close(os9path);
+	ASSERT_EQUALS(0, ec);
+ 
+	/* Copy from OS9 image to native filesystem */
+	ec = system("../os9/os9 copy test.dsk,meta.txt meta_out.txt > /dev/null 2>&1");
+	ASSERT_EQUALS(0, ec);
+ 
+	/* Read the OS9 file's modification time */
+	ec = _os9_open(&os9path, "test.dsk,meta.txt", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+	ec = _os9_gs_fd(os9path, os9_fstat_size, &os9_fstat);
+	ASSERT_EQUALS(0, ec);
+	ec = _os9_close(os9path);
+	ASSERT_EQUALS(0, ec);
+ 
+	/* Check that the native file's mtime matches the OS9 last_modified_time */
+	ec = stat("meta_out.txt", &native_stat);
+	ASSERT_EQUALS(0, ec);
+	UnixToOS9Time(native_stat.st_mtime, (char *) converted_native_fstat.fd_dat);
 	
-    remove("meta_out.txt");
+// 	fprintf(stderr, "os9_fstat.fd_dat: %d %d %d %d %d\n", os9_fstat.fd_dat[0], os9_fstat.fd_dat[1],os9_fstat.fd_dat[2], os9_fstat.fd_dat[3], os9_fstat.fd_dat[4]);
+// 	fprintf(stderr, "converted_native_fstat.fd_dat: %d %d %d %d %d\n", converted_native_fstat.fd_dat[0], converted_native_fstat.fd_dat[1],converted_native_fstat.fd_dat[2], converted_native_fstat.fd_dat[3], converted_native_fstat.fd_dat[4]);
+	
+	ASSERT_MEM_EQUALS(os9_fstat.fd_dat, converted_native_fstat.fd_dat, 5);
+ 
+	remove("meta_out.txt");
 }
 
 int main()

--- a/unittest/os9commandtest.c
+++ b/unittest/os9commandtest.c
@@ -8,6 +8,7 @@
 
 #include "tinytest.h"
 #include <toolshed.h>
+#include <utime.h>
 
 void test_os9_command_format()
 {
@@ -90,7 +91,45 @@ void test_os9_command_copy_metadata()
 // 	fprintf(stderr, "converted_native_fstat.fd_dat: %d %d %d %d %d\n", converted_native_fstat.fd_dat[0], converted_native_fstat.fd_dat[1],converted_native_fstat.fd_dat[2], converted_native_fstat.fd_dat[3], converted_native_fstat.fd_dat[4]);
 	
 	ASSERT_MEM_EQUALS(os9_fstat.fd_dat, converted_native_fstat.fd_dat, 5);
- 
+
+	/* Change the native file's mtime to a different fixed date:
+     * March 3, 1984 at 14:15 */
+    struct utimbuf native_utime;
+    struct tm native_tm;
+    memset(&native_tm, 0, sizeof(native_tm));
+    native_tm.tm_year = 84;  /* 1984 */
+    native_tm.tm_mon  = 2;   /* March */
+    native_tm.tm_mday = 3;
+    native_tm.tm_hour = 14;
+    native_tm.tm_min  = 15;
+    native_tm.tm_isdst = -1;
+    native_utime.modtime = mktime(&native_tm);
+    native_utime.actime  = native_utime.modtime;
+    ec = utime("meta_out.txt", &native_utime);
+    ASSERT_EQUALS(0, ec);
+
+    /* Copy native file back into the disk image */
+    ec = system("../os9/os9 copy meta_out.txt test.dsk,meta_back.txt > /dev/null 2>&1");
+    ASSERT_EQUALS(0, ec);
+
+    /* Read the OS9 file's modification time */
+    fd_stats os9_back_fstat;
+    ec = _os9_open(&os9path, "test.dsk,meta_back.txt", FAM_READ);
+    ASSERT_EQUALS(0, ec);
+    ec = _os9_gs_fd(os9path, os9_fstat_size, &os9_back_fstat);
+    ASSERT_EQUALS(0, ec);
+    ec = _os9_close(os9path);
+    ASSERT_EQUALS(0, ec);
+
+    /* Check that the OS9 file's mtime matches the native file's mtime */
+    fd_stats expected_back_fstat = {0};
+    UnixToOS9Time(native_utime.modtime, (char *) expected_back_fstat.fd_dat);
+
+// 	fprintf(stderr, "os9_back_fstat.fd_dat: %d %d %d %d %d\n", os9_back_fstat.fd_dat[0], os9_back_fstat.fd_dat[1],os9_back_fstat.fd_dat[2], os9_back_fstat.fd_dat[3], os9_back_fstat.fd_dat[4]);
+// 	fprintf(stderr, "expected_back_fstat.fd_dat: %d %d %d %d %d\n", expected_back_fstat.fd_dat[0], expected_back_fstat.fd_dat[1],expected_back_fstat.fd_dat[2], expected_back_fstat.fd_dat[3], expected_back_fstat.fd_dat[4]);
+
+    ASSERT_MEM_EQUALS(expected_back_fstat.fd_dat, os9_back_fstat.fd_dat, 5);
+
 	remove("meta_out.txt");
 }
 


### PR DESCRIPTION
Allen Huffman noticed the times and dates were not being copied in some cases of `os9 copy`. This fixes the ones I found.