### PR TITLE
cocoroms: Pick between md5 and md5sum

### DIFF
--- a/cocoroms/Makefile
+++ b/cocoroms/Makefile
@@ -1,3 +1,6 @@
+MD5_TOOL := $(shell command -v md5 >/dev/null 2>&1 && echo md5 || echo md5sum)
+
+
 all: bas13.rom extbas11.rom disk11.rom coco3.rom checksum
 
 bas13.rom: equates.asm bas.asm
@@ -19,7 +22,7 @@ coco3.rom: equates.asm coco3.asm
 	lwasm --raw -o $@ $^
 
 checksum:
-	md5 *.rom >md5sums-new.txt
+	$(MD5_TOOL) *.rom >md5sums-new.txt
 
 clean:
 	-rm -f cb_equates.asm ecb_equates.asm coco3.rom md5sums-new.txt


### PR DESCRIPTION
Linux, macOS, and others may have md5 or md5sum or both available.

Check to make sure the correct one is used.

I was getting an error on Ubuntu 26.04 where only md5sum is available.