### PR TITLE
os9 copy: add option to set file attributes during copy

### DIFF
--- a/os9/os9copy.c
+++ b/os9/os9copy.c
@@ -28,6 +28,7 @@ static char const *const helpMessage[] = {
 	"     -b=size    size of copy buffer in bytes or K-bytes\n",
 	"     -l         perform end of line translation\n",
 	"     -o=id      set file's owner as id\n",
+	"     -a=attrs   set file attributes (same syntax as attr)\n",
 	"     -r         rewrite if file exists\n",
 	NULL
 };
@@ -45,6 +46,9 @@ int os9copy(int argc, char *argv[])
 	char df[256];
 	int owner = 0, owner_set = 0;
 	char *buffer;
+	int attrSetMask = 0;
+	int attrResetMask = 0;
+	int attr_set = 0;
 	u_int buffer_size = 32768;
 
 
@@ -97,6 +101,82 @@ int os9copy(int argc, char *argv[])
 						owner_set = 1;
 					}
 					p = q;
+					break;
+
+				case 'a':
+					if (*(++p) == '=')
+						p++;
+
+					attr_set = 1;
+
+					while (*p != '\0')
+					{
+						switch (*p)
+						{
+						case 'e':
+							attrSetMask |= FAP_EXEC;
+							break;
+						case 'w':
+							attrSetMask |= FAP_WRITE;
+							break;
+						case 'r':
+							attrSetMask |= FAP_READ;
+							break;
+						case 's':
+							attrSetMask |= FAP_SINGLE;
+							break;
+						case 'p':
+							switch (*(++p))
+							{
+							case 'e':
+								attrSetMask |= FAP_PEXEC;
+								break;
+							case 'w':
+								attrSetMask |= FAP_PWRITE;
+								break;
+							case 'r':
+								attrSetMask |= FAP_PREAD;
+								break;
+							}
+							break;
+						case 'n':
+							switch (*(++p))
+							{
+							case 'p':
+								switch (*(++p))
+								{
+								case 'e':
+									attrResetMask |= FAP_PEXEC;
+									break;
+								case 'w':
+									attrResetMask |= FAP_PWRITE;
+									break;
+								case 'r':
+									attrResetMask |= FAP_PREAD;
+									break;
+								}
+								break;
+							case 'e':
+								attrResetMask |= FAP_EXEC;
+								break;
+							case 'w':
+								attrResetMask |= FAP_WRITE;
+								break;
+							case 'r':
+								attrResetMask |= FAP_READ;
+								break;
+							case 's':
+								attrResetMask |= FAP_SINGLE;
+								break;
+							case 'd':
+								attrResetMask |= FAP_DIR;
+								break;
+							}
+							break;
+						}
+						p++;
+					}
+					p--;
 					break;
 
 				case 'h':
@@ -283,6 +363,24 @@ int os9copy(int argc, char *argv[])
 
 		ec = TSCopyFile(argv[j], df, eolTranslate, rewrite, owner,
 				owner_set, buffer, buffer_size);
+
+		if (ec == 0 && attr_set)
+		{
+			char attr;
+			char attrs[9];
+			error_code ec2;
+
+			ec2 = TSRBFAttrSet(df,
+					   attrSetMask,
+					   attrResetMask,
+					   &attr,
+					   attrs);
+
+			if (ec2 != 0)
+				fprintf(stderr,
+					"%s: warning: copied '%s' but could not set attributes: %s\n",
+					argv[0], df, TSReportError(ec2));
+		}
 
 		if (ec != 0)
 		{


### PR DESCRIPTION
This change adds a new -a option to the os9 copy command that allows OS-9 file attributes to be set as part of the copy operation.
The attribute string uses the same syntax as the existing os9 attr command, allowing owner and public permissions to be set or cleared during the copy. Attributes are applied only after a successful copy, so existing behavior is unchanged when -a is not specified.
Examples:
`os9 copy -a=erpepr source dest`
Copies source to dest and sets owner read/execute and public read/execute permissions on the destination file.
This is particularly useful when installing executables, where the desired permissions can now be applied in a single step instead of requiring a separate attr command afterward.