### PR TITLE
decb: add binbust utility to strip DECB binary record headers

### DIFF
--- a/build/unix/decb/Makefile
+++ b/build/unix/decb/Makefile
@@ -6,7 +6,9 @@ vpath %.c ../../../decb ../../../os9
 CFLAGS	+= -I../../../include -Wall -MMD -MP
 
 SRCS = decb_main.c decbattr.c decbcopy.c decbdir.c decbdskini.c decbfree.c decbfstat.c \
-	decbhdbconv.c decbkill.c decblist.c decbrename.c os9dump.c decbdsave.c os9dsave.c
+	decbhdbconv.c decbkill.c decblist.c decbrename.c os9dump.c decbdsave.c decbbinbust.c \
+	os9dsave.c
+	
 OBJS = $(SRCS:.c=.o)
 DEPS = $(OBJS:.o=.d)
 

--- a/decb/decb_main.c
+++ b/decb/decb_main.c
@@ -40,6 +40,7 @@ struct cmdtbl
 
 static struct cmdtbl table[] = {
 	{decbattr, "attr"},
+	{decbbinbust, "binbust"},
 	{decbcopy, "copy"},
 	{decbdir, "dir"},
 	{decbdsave, "dsave"},

--- a/decb/decbbinbust.c
+++ b/decb/decbbinbust.c
@@ -1,0 +1,135 @@
+/********************************************************************
+ * binbust.c - Remove DECB binary ambles.
+ ********************************************************************/
+
+#include <util.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <cocopath.h>
+
+static char const *const helpMessage[] = {
+    "Syntax: binbust <input> <output>\n",
+    "Usage:  Strip DECB binary pre-, inner-, and post- ambles.\n",
+    NULL
+};
+
+static uint16_t be16(const uint8_t *p)
+{
+    return ((uint16_t)p[0] << 8) | p[1];
+}
+
+int decbbinbust(int argc, char *argv[])
+{
+    coco_path_id in = NULL, out = NULL;
+    error_code ec = 0;
+    uint8_t hdr[5];
+
+    if (argc != 3)
+    {
+        show_help(helpMessage);
+        return 0;
+    }
+
+    ec = _coco_open(&in, argv[1], FAM_READ);
+    if (ec != 0)
+    {
+        fprintf(stderr, "%s: error %d opening '%s'\n",
+                argv[0], ec, argv[1]);
+        return ec;
+    }
+
+    coco_file_stat stat = { 0 };
+
+    ec = _coco_create(&out, argv[2], FAM_WRITE, &stat);
+    if (ec != 0)
+    {
+        fprintf(stderr, "%s: error %d creating '%s'\n",
+                argv[0], ec, argv[2]);
+        _coco_close(in);
+        return ec;
+    }
+
+    for (;;)
+    {
+        uint16_t length;
+        uint16_t address;
+        u_int size = sizeof(hdr);
+
+        ec = _coco_read(in, hdr, &size);
+        if (ec != 0 || size != sizeof(hdr))
+        {
+            fprintf(stderr, "Unexpected EOF\n");
+            break;
+        }
+
+        length  = be16(&hdr[1]);
+        address = be16(&hdr[3]);
+
+        switch (hdr[0])
+        {
+        case 0x00:
+        {
+            uint8_t *buffer;
+
+            (void)address;
+
+            if (length == 0)
+                break;
+
+            buffer = malloc(length);
+            if (buffer == NULL)
+            {
+                fprintf(stderr, "Out of memory\n");
+                ec = EOS_MF;
+                goto done;
+            }
+
+            size = length;
+            ec = _coco_read(in, buffer, &size);
+            if (ec != 0 || size != length)
+            {
+                fprintf(stderr, "Unexpected EOF in data block\n");
+                free(buffer);
+                goto done;
+            }
+
+            size = length;
+            ec = _coco_write(out, buffer, &size);
+            free(buffer);
+
+            if (ec != 0 || size != length)
+            {
+                fprintf(stderr, "Write error\n");
+                goto done;
+            }
+
+            break;
+        }
+
+        case 0xff:
+            if (length != 0)
+            {
+                fprintf(stderr, "Malformed end record\n");
+            }
+            goto done;
+
+        default:
+            fprintf(stderr,
+                    "Unknown block type $%02X\n",
+                    hdr[0]);
+            ec = EOS_IC;
+            goto done;
+        }
+    }
+
+done:
+    if (in != NULL)
+        _coco_close(in);
+
+    if (out != NULL)
+        _coco_close(out);
+
+    return ec;
+}

--- a/doc/ToolShed.md
+++ b/doc/ToolShed.md
@@ -39,6 +39,7 @@ ToolShed v2.5.1
 * [decb](#decb) - Manipulate RSDOS formatted disk images
   * [Options](#decb_exec_option) - The DECB executive's option
   * [ATTR](#attr_decb) - Display or modify file attributes
+  * [BINBUST](#binbust) - Remove ambles from DECB binaries
   * [COPY](#copy_decb) - Copy one or more files to a target directory
   * [DIR](#dir_decb) - Display the directory of a Disk BASIC image
   * [DSAVE](#dsave_decb) - Copy the contents of a directory or device
@@ -852,6 +853,30 @@ Every file in the Disk BASIC file system possesses attributes. These attributes 
 Change a file's attribute to a text file:
 
     decb attr decb.dsk,TEST.DAT -3
+
+---
+
+<h3 id="binbust">BINBUST - Remove ambles from DECB binaries</h3>
+
+#### Syntax and Scope
+
+    binbust <input file> <output file>
+
+This command is for a file from anywhere.
+
+#### Options
+
+No options.
+
+#### Description
+
+DECB binary files are composed of one or more data records, each preceded by a 5-byte header (type, length, load address), followed by a final 5-byte execution record. Binbust removes these record headers and trailers, concatenating the data blocks into a single unadorned binary file.
+
+#### Examples
+
+Process a file:
+
+    decb binbust decb.dsk,EPROM.BIN dos.bin
 
 ---
 

--- a/include/decbutil.h
+++ b/include/decbutil.h
@@ -46,6 +46,7 @@ int decbpadrom(int, char **);
 int decbrename(int, char **);
 int decbdump(int, char**);
 int decbdsave(int, char**);
+int decbbinbust(int, char **);
 
 #ifdef __cplusplus
 }

--- a/include/util.h
+++ b/include/util.h
@@ -65,6 +65,7 @@ int decbrename(int, char **);
 int decbdump(int, char **);
 int decbhdbconv(int, char **);
 int decbdsave(int, char**);
+int decbbinbust(int, char**);
 
 /* Function prototypes for supported Disk BASIC commands are here */
 int cecbdir(int, char **);


### PR DESCRIPTION
DECB binary files are composed of one or more data records, each preceded by a 5-byte header (type, length, load address), followed by a final 5-byte execution record. `binbust` removes these record headers and trailers, concatenating the data blocks into a single unadorned binary file.

Features:
- Supports DECB binaries with any number of data records.
- Validates record types and end records.
- Uses the CoCo path API, allowing input and output on native, DECB, OS-9, and CECB filesystems.
- Reports malformed binaries and unexpected EOF conditions.

This utility is useful when extracting firmware or ROM images from DECB machine-language binaries for analysis, disassembly, or use with other tools.