### PR TITLE
toolshed: Add Bash/Zsh completion scripts and document their use

### DIFF
--- a/cecb/cecb-completion.bash
+++ b/cecb/cecb-completion.bash
@@ -1,0 +1,126 @@
+# Bash completion for the `cecb` ToolShed command (CECB File Tools Executive)
+# Source this file (e.g. from ~/.bashrc) or drop it in
+# /etc/bash_completion.d/ or /usr/local/etc/bash_completion.d/
+
+_cecb()
+{
+    local cur prev cmd
+    COMPREPLY=()
+
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Global options
+    local global_opts="
+        -r
+        -t
+        -n
+        -s
+        -z
+    "
+
+    # Subcommands
+    local commands="
+        bulkerase
+        copy
+        dir
+        dumpblock
+        fstat
+        leader
+    "
+
+    #
+    # Find the subcommand (first non-option argument).
+    #
+    cmd=
+    for ((i=1; i<COMP_CWORD; i++)); do
+        case "${COMP_WORDS[i]}" in
+            -*)
+                ;;
+            *)
+                cmd="${COMP_WORDS[i]}"
+                break
+                ;;
+        esac
+    done
+
+    #
+    # No subcommand yet.
+    #
+    if [[ -z "$cmd" ]]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "$global_opts" -- "$cur") )
+        else
+            COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+        fi
+        return
+    fi
+
+    case "$cmd" in
+        bulkerase)
+            case "$prev" in
+                -s)
+                    COMPREPLY=( $(compgen -W "11025 22050 44100 48000 96000" -- "$cur") )
+                    return
+                    ;;
+                -b)
+                    COMPREPLY=( $(compgen -W "8 16 24 32" -- "$cur") )
+                    return
+                    ;;
+            esac
+
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "
+                    -s
+                    -b
+                    -l
+                " -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -f -- "$cur") )
+            fi
+            ;;
+
+        copy)
+            case "$prev" in
+                -d|-e)
+                    return
+                    ;;
+            esac
+
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "
+                    -0
+                    -1
+                    -2
+                    -3
+                    -a
+                    -b
+                    -g
+                    -n
+                    -d
+                    -e
+                    -l
+                    -t
+                    -k
+                    -s
+                    -f
+                    -c
+                    -p
+                " -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -f -- "$cur") )
+            fi
+            ;;
+
+        dir|fstat|leader|dumpblock)
+            if [[ "$cur" == -* ]]; then
+                [[ "$cmd" == dumpblock ]] &&
+                    COMPREPLY=( $(compgen -W "-h" -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -f -- "$cur") )
+            fi
+            ;;
+    esac
+}
+
+complete -F _cecb cecb

--- a/cecb/cecb_zsh.txt
+++ b/cecb/cecb_zsh.txt
@@ -1,0 +1,127 @@
+#compdef cecb
+#
+# Copy this file to a special directory as _cecb (plain filename with underscore)
+# Check your $fpath for possible locations
+
+# Show ambiguous completions immediately instead of beeping first
+setopt AUTO_LIST
+setopt NO_LIST_BEEP     # optional: silence the bell entirely
+
+_cecb() {
+    local context state state_descr line
+    typeset -A opt_args
+
+    local -a global_opts
+    global_opts=(
+        '-r+[Set WAV FSK aspect ratio]:ratio:'
+        '-t+[Set WAV FSK aspect ratio threshold]:threshold:'
+        '-n+[Set near-zero threshold]:threshold:'
+        '-s+[Start at sample/bit]:offset:'
+        '-z[Suggest MC-10 mode]'
+    )
+
+    local -a commands
+    commands=(
+        'bulkerase:Create cassette image files'
+        'copy:Copy files to an image'
+        'dir:Display image directory'
+        'dumpblock:Hex dump cassette blocks'
+        'dump:Display the contents of a file in hexadecimal'
+        'fstat:Display file information'
+        'leader:Analyze WAV leaders'
+    )
+
+    # Use *:: to shift $words so $words[1] becomes the subcommand in the nested state
+    _arguments -s -C \
+        $global_opts \
+        '1:command:->command' \
+        '*::subcommand args:->args'
+
+    case $state in
+        command)
+            _describe 'cecb command' commands
+            ;;
+        args)
+            # Since *:: shifted $words, the subcommand is now exactly $words[1]
+            local cmd="$words[1]"
+            
+            case "$cmd" in
+                bulkerase)
+                    _arguments -s \
+                        $global_opts \
+                        '-s+[Sample rate]:sample rate:(11025 22050 44100 48000 96000)' \
+                        '-b+[Bits per sample]:bits:(8 16 24 32)' \
+                        '-l+[Leader silence length]:seconds:' \
+                        '*:file:_files'
+                    ;;
+
+                copy)
+                    _arguments -s \
+                        $global_opts \
+                        '-0[BASIC program]' \
+                        '-1[BASIC data file]' \
+                        '-2[Machine-language program]' \
+                        '-3[Text editor source file]' \
+                        '-a[ASCII data]' \
+                        '-b[Binary data]' \
+                        '-g[Write gaps]' \
+                        '-n[No gaps]' \
+                        '-d+[Load address]:address:' \
+                        '-e+[Execution address]:address:' \
+                        '-l[Translate line endings]' \
+                        '-t[Entokenize BASIC text]' \
+                        '-k[Detokenize BASIC program]' \
+                        '-s[Encode Motorola S-record]' \
+                        '-f[Decode Motorola S-record]' \
+                        '-c[Concatenate machine-language segments]' \
+                        '-p[Honor global start position]' \
+                        '*:file:_files'
+                    ;;
+
+                dir)
+                    _arguments -s \
+                        $global_opts \
+                        '*:image:_files'
+                    ;;
+
+                dump)
+                    _arguments -s \
+                        $global_opts \
+                        '-a[dump output in assembler format (hex)]' \
+                        '-b[dump output in assembler format (binary)]' \
+                        "-c[don't display ASCII character data]" \
+                        '-e[dump output in C format]' \
+                        "-t[don't display header]" \
+                        "-h[don't display header (DEPRECATED)]" \
+                        "-l[don't display line label/count]" \
+                        '-z[decode DECB binary]' \
+                        '*:file:_files'
+                    ;;
+
+                dumpblock)
+                    _arguments -s \
+                        $global_opts \
+                        '-h[Show help]' \
+                        '*:image:_files'
+                    ;;
+
+                fstat)
+                    _arguments -s \
+                        $global_opts \
+                        '*:file:_files'
+                    ;;
+
+                leader)
+                    _arguments -s \
+                        $global_opts \
+                        '*:wave file:_files'
+                    ;;
+            case)
+                    _message "unknown cecb command: $cmd"
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_cecb "$@"

--- a/decb/decb-completion.bash
+++ b/decb/decb-completion.bash
@@ -1,0 +1,91 @@
+# Bash completion for the `decb` ToolShed command (DECB File Tools Executive)
+# Source this file (e.g. from ~/.bashrc) or drop it in
+# /etc/bash_completion.d/ or /usr/local/etc/bash_completion.d/
+
+_decb()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    local commands="
+        attr
+        binbust
+        copy
+        dir
+        dsave
+        dskini
+        free
+        fstat
+        hdbconv
+        kill
+        list
+        rename
+    "
+
+    # Complete command name
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+        return
+    fi
+
+    local cmd="${words[1]}"
+
+    case "$cmd" in
+        attr)
+            COMPREPLY=( $(compgen -W \
+                "-0 -1 -2 -3 -a -b" -- "$cur") )
+            ;;
+
+        binbust)
+            _filedir
+            ;;
+
+        copy)
+            COMPREPLY=( $(compgen -W \
+                "-0 -1 -2 -3 -a -b -l -r -t -c" -- "$cur") )
+            if [[ "$cur" != -* ]]; then
+                _filedir
+            fi
+            ;;
+
+        dir|free|kill|fstat|list)
+            if [[ "$cur" != -* ]]; then
+                _filedir
+            fi
+            ;;
+
+        dsave)
+            COMPREPLY=( $(compgen -W \
+                "-b= -e -l -t -r" -- "$cur") )
+            if [[ "$cur" != -* ]]; then
+                _filedir
+            fi
+            ;;
+
+        dskini)
+            COMPREPLY=( $(compgen -W \
+                "-3 -4 -8 -h -n -s" -- "$cur") )
+            if [[ "$cur" != -* ]]; then
+                _filedir
+            fi
+            ;;
+
+        hdbconv)
+            COMPREPLY=( $(compgen -W \
+                "-2 -5" -- "$cur") )
+            if [[ "$cur" != -* ]]; then
+                _filedir
+            fi
+            ;;
+
+        rename)
+            _filedir
+            ;;
+
+        *)
+            COMPREPLY=( $(compgen -W "-g" -- "$cur") )
+            ;;
+    esac
+}
+
+complete -F _decb decb

--- a/decb/decb_zsh.txt
+++ b/decb/decb_zsh.txt
@@ -1,0 +1,146 @@
+#compdef decb
+#
+# Copy this file to a special directory as _decb (plain filename with underscore)
+# Check your $fpath for possible locations
+
+# Show ambiguous completions immediately instead of beeping first
+setopt AUTO_LIST
+setopt NO_LIST_BEEP     # optional: silence the bell entirely
+
+_decb() {
+    local -a commands
+    local -a global_opts
+
+    commands=(
+        'attr:Display or modify file attributes'
+        'binbust:Strip DECB binary pre-, inner-, and post-ambles'
+        'copy:Copy one or more files to a target directory'
+        'dir:Display the contents of a directory'
+        'dsave:Copy the contents of a directory or device'
+        'dskini:Create a Disk BASIC image'
+        'free:Display the amount of free space on an image'
+        'fstat:Display detailed information about a file'
+        'dump:hex dump information about a file'
+        'hdbconv:Convert HDB-DOS disk images'
+        'kill:Delete one or more files'
+        'list:Display contents of a text file'
+        'rename:Give a file a new filename'
+    )
+
+    global_opts=(
+        '-g[Granule count in FAT]:granule count:(68 78 156)'
+    )
+
+    # Find the command word
+    if (( CURRENT == 2 )); then
+        _arguments \
+			'-g[Granule count in FAT]:granule count:(68 78 156)' \
+			'1:command:->commands'
+
+        case $state in
+            commands)
+                _describe -t commands 'decb command' commands
+                ;;
+        esac
+        return
+    fi
+
+    # The first non-option argument is the subcommand
+    local cmd
+    cmd=${words[(I)${commands%%:*}]}
+    cmd=${words[2]}
+
+    case $cmd in
+        attr)
+            _arguments \
+                '-0[BASIC program]' \
+                '-1[BASIC data file]' \
+                '-2[Machine-language program]' \
+                '-3[Text file]' \
+                '-a[ASCII file]' \
+                '-b[Binary file]' \
+                '*:file:_files'
+            ;;
+
+        binbust)
+            _arguments \
+                '1:input file:_files' \
+                '2:output file:_files'
+            ;;
+
+        copy)
+            _arguments \
+                '-0[file type: BASIC program]' \
+                '-1[file type: BASIC data file]' \
+                '-2[file type: machine-language program]' \
+                '-3[file type: text editor source file]' \
+                '-a[ASCII data]' \
+                '-b[Binary data]' \
+                '-l[Perform end of line translation]' \
+                '-r[Rewrite if file exists]' \
+                '-t[Perform BASIC token translation]' \
+                '-c[Concatenate machine language segments]' \
+                '*:file:_files'
+            ;;
+
+        dir|free|kill|fstat|list)
+            _arguments \
+                '*:file:_files'
+            ;;
+
+        dsave)
+            _arguments \
+                '-b[size of copy buffer]' \
+                '-e[Execute commands]' \
+                '-l[Perform end of line translation]' \
+                '-t[Perform BASIC token translation]' \
+                '-r[Force rewrite]' \
+                '*:file:_files'
+            ;;
+
+        dump)
+            _arguments \
+                '-a[dump output in assembler format (hex)]' \
+                '-b[dump output in assembler format (binary)]' \
+                '-c[don't display ASCII character data' \
+                '-e[dump output in C format' \
+                '-t[don't display header]' \
+                '-h[don't display header (DEPRECATED)]' \
+                '-l[don't display line label/count]' \
+                '-z[decode DECB binary]' \
+                '*:file:_files'
+            ;;
+
+        dskini)
+            _arguments \
+                '-3[35 track disk]' \
+                '-4[40 track disk]' \
+                '-8[80 track disk]' \
+                '-h[number of HDB-DOS drives]:drives' \
+                '-n[disk name]:name' \
+                '-s[Create skitzo disk]' \
+                '*:disk image:_files'
+            ;;
+
+        hdbconv)
+            _arguments \
+                '-2[512-byte sector to 256-byte sector]' \
+                '-5[256-byte sector to 512-byte sector]' \
+                '*:file:_files'
+            ;;
+
+        rename)
+            _arguments \
+                '1:file:_files' \
+                '2:new filename'
+            ;;
+
+        *)
+            _arguments \
+				'-g[Granule count in FAT]:granule count:(68 78 156)' \
+				'*:file:_files'
+            ;;
+    esac
+}
+
+_decb "$@"

--- a/doc/ToolShed.md
+++ b/doc/ToolShed.md
@@ -212,11 +212,14 @@ The number after the plus is the offset. It can be expressed in decimal or hexad
 ---
 
 <h2 id="os9">os9</h2>
-The following pages document the commands built into the os9 tool. As the examples above illustrated, the built in commands such as dir, copy, etc. must be executed from the os9 executive, and any parameters for that command follow the command name.
+The following pages document the commands built into the **os9** tool. As the examples above illustrated, the built-in commands such as **dir**, **copy**, etc. must be executed from the **os9** executive, and any parameters for that command follow the command name.
 
-Issuing the os9 command without any parameters will provide a list of available subcommands. Issuing a subcommand without any parameters will display help on using the subcommand.
+Issuing the **os9** command without any parameters will provide a list of available subcommands. Issuing a subcommand without any parameters will display help on using that subcommand.
 
-While many commands will work fine host file systems, some commands are designed to only be run on an RBF disk image or file within that image. The Scope section makes it clear in what context the command should be run.
+To make working with the **os9** executive more convenient, Toolshed includes shell completion definitions for both Bash and Zsh. The files **os9-completion.bash** and **os9_zsh.txt** provide tab completion for subcommands and many command options. To install them manually, copy **os9-completion.bash** into your Bash completion directory (or source it from your `~/.bashrc`) or copy **os9_zsh.txt** into a directory in your Zsh `$fpath`, rename it to **_os9**, and run `compinit` (or source it directly from your `~/.zshrc`).
+
+While many commands will work fine on host file systems, some commands are designed to only be run on an RBF disk image or on a file within that image. The **Scope** section makes it clear in what context a command should be run.
+
 
 ---
 
@@ -810,11 +813,14 @@ The rename command renames a file with a new filename.
 
 <h2 id="decb">decb</h2>
 
-The following pages document the commands built into the decb tool. Its interface is similar to that of the os9 tool discussed in previous pages.
+The following pages document the commands built into the **decb** tool. Its interface is similar to that of the **os9** tool discussed in previous pages.
 
-Issuing the decb command without any parameters will provide a list of available subcommands. Issuing a subcommand without any parameters will display help on using the subcommand.
+Issuing the **decb** command without any parameters will provide a list of available subcommands. Issuing a subcommand without any parameters will display help on using that subcommand.
 
-Use decb to copy files to and from Disk BASIC formatted disk images to your host file system. While many commands will work fine host file systems, some commands are designed to only be run on a Disk BASIC disk image or file within that image. The Scope section makes it clear in what context the command should be run.
+To make working with the **decb** executive more convenient, Toolshed includes shell completion definitions for both Bash and Zsh. The files **decb-completion.bash** and **decb_zsh.txt** provide tab completion for subcommands and many command options. To install them manually, copy **decb-completion.bash** into your Bash completion directory (or source it from your `~/.bashrc`) or copy **decb_zsh.txt** into a directory in your Zsh `$fpath`, rename it to **_decb**, and run `compinit` (or source it directly from your `~/.zshrc`).
+
+Use **decb** to copy files to and from Disk BASIC formatted disk images and your host file system. While many commands will work fine on host file systems, some commands are designed to only be run on a Disk BASIC disk image or on a file within that image. The **Scope** section makes it clear in what context a command should be run.
+
 
 <h3 id="decb_exec_option">The DECB executive's option</h3>
 
@@ -1165,11 +1171,14 @@ The rename command renames a file with a new filename.
 
 <h2 id="cecb">cecb</h2>
 
-The following pages document the commands built into the cecb tool. Its interface is similar to that of the os9 tool discussed in previous pages.
+The following pages document the commands built into the **cecb** tool. Its interface is similar to that of the **os9** tool discussed in previous pages.
 
-Issuing the cecb command without any parameters will provide a list of available subcommands. Issuing a subcommand without any parameters will display help on using the subcommand.
+Issuing the **cecb** command without any parameters will provide a list of available subcommands. Issuing a subcommand without any parameters will display help on using that subcommand.
 
-Use cecb to copy files to and from Color BASIC and Micro Color BASIC formatted cassette images to your host file system. While many commands will work fine with host file systems, some commands are designed to only be run on a BASIC cassette image or file within that image. The Scope section makes it clear in what context the command should be run.
+To make working with the **cecb** executive more convenient, Toolshed includes shell completion definitions for both Bash and Zsh. The files **cecb-completion.bash** and **cecb_zsh.txt** provide tab completion for subcommands and many command options. To install them manually, copy **cecb-completion.bash** into your Bash completion directory (or source it from your `~/.bashrc`) or copy **cecb_zsh.txt** into a directory in your Zsh `$fpath`, rename it to **_cecb**, and run `compinit` (or source it directly from your `~/.zshrc`).
+
+Use **cecb** to copy files to and from Color BASIC and Micro Color BASIC formatted cassette images and your host file system. While many commands will work fine with host file systems, some commands are designed to only be run on a BASIC cassette image or on a file within that image. The **Scope** section makes it clear in what context a command should be run.
+
 
 Cecb can work with WAV, CAS, and C10 cassette file containers.
 

--- a/os9/os9-completion.bash
+++ b/os9/os9-completion.bash
@@ -1,0 +1,80 @@
+# Bash completion for the `os9` ToolShed command (OS-9 File Tools Executive)
+# Source this file (e.g. from ~/.bashrc) or drop it in
+# /etc/bash_completion.d/ or /usr/local/etc/bash_completion.d/
+
+_os9_commands="attr cmp copy dcheck del deldir dir dsave dump format free fstat gen id ident list makdir modbust padrom rdump rename"
+
+_os9_opts_attr="-q -e -w -r -s -p -n -np"
+_os9_opts_cmp=""
+_os9_opts_copy="-b -l -o -a -r"
+_os9_opts_dcheck="-s -b -p"
+_os9_opts_del=""
+_os9_opts_deldir="-q"
+_os9_opts_dir="-a -e -r"
+_os9_opts_dsave="-b -e -l -r"
+_os9_opts_dump="-a -b -c -e -t -h -l -z"
+_os9_opts_format="-bs -c -e -k -n -q -4 -9 -sa -sd -dd -ss -ds -t -st -sz -i -dr -l"
+_os9_opts_free=""
+_os9_opts_fstat=""
+_os9_opts_gen="-b -c -d -e -t -l"
+_os9_opts_id=""
+_os9_opts_ident="-s"
+_os9_opts_list=""
+_os9_opts_makdir=""
+_os9_opts_modbust=""
+_os9_opts_padrom="-b -c"
+_os9_opts_rdump="-g -r -o -a"
+_os9_opts_rename=""
+
+# Options that take a value directly attached, e.g. -b=size or -bs256.
+# We still just offer them as tokens; bash completion doesn't do the
+# rich "expects an argument" prompting that zsh's _arguments does.
+_os9_takes_value_attr="-b -bs -c -n -st -sz -i -l -o -a"
+
+_os9() {
+    local cur prev words cword
+    _init_completion 2>/dev/null || {
+        # Fallback if bash-completion's _init_completion isn't available
+        COMPREPLY=()
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+        words=("${COMP_WORDS[@]}")
+        cword=$COMP_CWORD
+    }
+
+    local subcmd="${words[1]}"
+
+    # No subcommand yet, or still typing it: complete subcommand names
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$_os9_commands" -- "$cur") )
+        return 0
+    fi
+
+    # Make sure the subcommand is one we know; otherwise fall back to files
+    if [[ ! " $_os9_commands " == *" $subcmd "* ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+    fi
+
+    local opts_var="_os9_opts_${subcmd}"
+    local opts="${!opts_var}"
+
+    # Completing an option value for options that take one
+    if [[ " $_os9_takes_value_attr " == *" $prev "* ]]; then
+        COMPREPLY=()
+        return 0
+    fi
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return 0
+    fi
+
+    # Default: complete filenames. Note that OS-9 paths often look like
+    # `image.dsk,path/inside/image` (host disk image + in-image path
+    # separated by a comma) rather than a plain host filesystem
+    # directory, so we don't restrict any subcommand to compgen -d.
+    COMPREPLY=( $(compgen -f -- "$cur") )
+}
+
+complete -F _os9 os9

--- a/os9/os9_zsh.txt
+++ b/os9/os9_zsh.txt
@@ -1,0 +1,270 @@
+#compdef os9
+#
+# Copy this file to a special directory as _os9 (plain filename with underscore)
+# Check your $fpath for possible locations
+
+# Show ambiguous completions immediately instead of beeping first
+setopt AUTO_LIST
+setopt NO_LIST_BEEP     # optional: silence the bell entirely
+
+_os9() {
+    local context state state_descr line
+    typeset -A opt_args
+
+    local -a commands
+    commands=(
+        'attr:Display or modify file attributes'
+        'cmp:Compare the contents of two files'
+        'copy:Copy one or more files to a target directory'
+        'dcheck:Verify the file structure of a disk image'
+        'del:Delete one or more files'
+        'deldir:Delete a directory and its contents'
+        'dir:Display the contents of a directory'
+        'dsave:Copy the contents of a directory or device'
+        'dump:Display the contents of a file in hexadecimal'
+        'format:Create a disk image of a given size'
+        'free:Display the amount of free space on an image'
+        'fstat:Display the file descriptor sector for a file'
+        'gen:Prepare the disk image for booting'
+        'id:Display sector 0 of an image'
+        'ident:Display OS-9 module information'
+        'list:Display contents of a text file'
+        'makdir:Create one or more directories'
+        'modbust:Bust a single merged file of OS-9 modules into separate files'
+        'padrom:Pad a file to a specific length'
+        'rdump:Print formatted dump of .r and .l files'
+        'rename:Give a file a new filename'
+    )
+
+    _arguments -C \
+        '1: :->command' \
+        '*:: :->args'
+
+    case $state in
+        command)
+            _describe -t commands 'os9 command' commands
+            ;;
+        args)
+            case $line[1] in
+                attr)    _os9_attr    ;;
+                cmp)     _os9_cmp     ;;
+                copy)    _os9_copy    ;;
+                dcheck)  _os9_dcheck  ;;
+                del)     _os9_del     ;;
+                deldir)  _os9_deldir  ;;
+                dir)     _os9_dir     ;;
+                dsave)   _os9_dsave   ;;
+                dump)    _os9_dump    ;;
+                format)  _os9_format  ;;
+                free)    _os9_free    ;;
+                fstat)   _os9_fstat   ;;
+                gen)     _os9_gen     ;;
+                id)      _os9_id      ;;
+                ident)   _os9_ident   ;;
+                list)    _os9_list    ;;
+                makdir)  _os9_makdir  ;;
+                modbust) _os9_modbust ;;
+                padrom)  _os9_padrom  ;;
+                rdump)   _os9_rdump   ;;
+                rename)  _os9_rename  ;;
+            esac
+            ;;
+    esac
+}
+
+# ---- attr ----
+_os9_attr() {
+    _arguments \
+        '-q[quiet mode (suppress output)]' \
+        '-e[set execute permission]' \
+        '-w[set write permission]' \
+        '-r[set read permission]' \
+        '-s[set single user permission]' \
+        '-p+[set public permission (append e/w/r)]' \
+        '-n+[unset owner permissions (append e/w/r/s)]' \
+        '-np+[unset public permissions (append e/w/r)]' \
+        '*:file:_files'
+}
+
+# ---- cmp ----
+_os9_cmp() {
+    _arguments \
+        '1:first file:_files' \
+        '*:additional file:_files'
+}
+
+# ---- copy ----
+_os9_copy() {
+    _arguments \
+        '-b=-[size of copy buffer in bytes or K-bytes]:size' \
+        '-l[perform end of line translation]' \
+        '-o=-[set file'"'"'s owner as id]:owner id' \
+        '-a=-[set file attributes (same syntax as attr)]:attrs' \
+        '-r[rewrite if file exists]' \
+        '*:file:_files' \
+        ':target:_files -/'
+}
+
+# ---- dcheck ----
+_os9_dcheck() {
+    _arguments \
+        '-s[check number of directories/files, verify file descriptors only]' \
+        '-b[suppress listing of unused clusters]' \
+        '-p[print pathlists of questionable clusters]' \
+        '*:disk image:_files'
+}
+
+# ---- del ----
+_os9_del() {
+    _arguments \
+        '*:file:_files'
+}
+
+# ---- deldir ----
+_os9_deldir() {
+    _arguments \
+        '-q[quiet mode (suppress interaction)]' \
+        '1:directory:_files -/'
+}
+
+# ---- dir ----
+_os9_dir() {
+    _arguments \
+        '-a[show all files]' \
+        '-e[extended directory]' \
+        '-r[recurse directories]' \
+        '*:directory:_files -/'
+}
+
+# ---- dsave ----
+_os9_dsave() {
+    _arguments \
+        '-b=-[size of copy buffer in bytes or K-bytes]:size' \
+        '-e[actually execute commands]' \
+        '-l[perform end of line translation on copy]' \
+        '-r[force rewrite on copy]' \
+        ':source:_files' \
+        ':target:_files'
+}
+
+# ---- dump ----
+_os9_dump() {
+    _arguments \
+        '-a[dump output in assembler format (hex)]' \
+        '-b[dump output in assembler format (binary)]' \
+        '-c[don'"'"'t display ASCII character data]' \
+        '-e[dump output in C format]' \
+        '-t[don'"'"'t display header]' \
+        '-h[don'"'"'t display header (DEPRECATED)]' \
+        '-l[don'"'"'t display line label/count]' \
+        '-z[decode DECB binary]' \
+        '*:file:_files'
+}
+
+# ---- format ----
+_os9_format() {
+    _arguments \
+        '-bs+[bytes per sector (default 256)]:bytes per sector' \
+        '-c+[cluster size]:cluster size' \
+        '-e[format entire disk (make full sized image)]' \
+        '-k[make OS-9/68K LSN0]' \
+        '-n+[disk name]:disk name' \
+        '-q[quiet; do not report format summary]' \
+        '-4[48 tpi (default)]' \
+        '-9[96 tpi]' \
+        '-sa[sector allocation size (SAS)]' \
+        '-sd[single density]' \
+        '-dd[double density (default)]' \
+        '-ss[single sided (default)]' \
+        '-ds[double sided]' \
+        '-t+[tracks (default 35)]:tracks' \
+        '-st+[sectors per track (default 18)]:sectors per track' \
+        '-sz+[sectors for track 0 (default 18)]:sectors for track 0' \
+        '-i+[interleave (default 3)]:interleave' \
+        '-dr[format a Dragon disk]' \
+        '-l+[number of logical sectors (hard drive; floppy options ignored)]:logical sectors' \
+        '*:disk image:_files'
+}
+
+# ---- free ----
+_os9_free() {
+    _arguments \
+        '*:disk image:_files'
+}
+
+# ---- fstat ----
+_os9_fstat() {
+    _arguments \
+        '*:file:_files'
+}
+
+# ---- gen ----
+_os9_gen() {
+    _arguments \
+        '-b=-[bootfile to copy and link to the image]:bootfile:_files' \
+        '-c[CoCo disk (default)]' \
+        '-d[Dragon disk]' \
+        '-e[extended boot (fragmented)]' \
+        '-t=-[kernel trackfile to copy to the image]:trackfile:_files' \
+        '-l+[special boottrack/kerneltrack start LSN]:LSN' \
+        ':disk image:_files'
+}
+
+# ---- id ----
+_os9_id() {
+    _arguments \
+        '*:disk image:_files'
+}
+
+# ---- ident ----
+_os9_ident() {
+    _arguments \
+        '-s[short output]' \
+        '*:file:_files'
+}
+
+# ---- list ----
+_os9_list() {
+    _arguments \
+        '*:file:_files'
+}
+
+# ---- makdir ----
+_os9_makdir() {
+    _arguments \
+        '*:directory:_files -/'
+}
+
+# ---- modbust ----
+_os9_modbust() {
+    _arguments \
+        '*:file:_files'
+}
+
+# ---- padrom ----
+_os9_padrom() {
+    _arguments \
+        '-b[place padding at the beginning of the file]' \
+        '-c+[character to pad (n=dec, %bin, 0oct or \$hex)]:pad char' \
+        '1:pad size:' \
+        '*:file:_files'
+}
+
+# ---- rdump ----
+_os9_rdump() {
+    _arguments \
+        '-g[add global definition info]' \
+        '-r[add reference info]' \
+        '-o[add reference and local offset info]' \
+        '-a[all of the above]' \
+        '*:file:_files'
+}
+
+# ---- rename ----
+_os9_rename() {
+    _arguments \
+        '1:file:_files' \
+        '2:new filename:'
+}
+
+_os9 "$@"


### PR DESCRIPTION
This PR adds static command-line completion scripts for the Toolshed utilities:

- os9
- decb
- cecb

The completion scripts support the commands, subcommands, and documented options, making the tools easier to discover and use from the command line.

The manual has also been updated to:
- Document the availability of the completion scripts.
- Explain how to install and enable them for both Bash and Zsh.

This PR intentionally does **not** modify the build system or Makefiles to install the completion scripts automatically. Users who want shell completion must install the scripts manually as described in the documentation. This avoids introducing platform-specific installation behavior while still making the scripts available for users and package maintainers.