### PR TITLE
refactor(os9gen): add support for embedded bootstrap and boottrack files.

### DIFF
--- a/doc/ToolShed.md
+++ b/doc/ToolShed.md
@@ -653,6 +653,26 @@ This command will work on RBF disk images only.
 
 The gen command gives a disk image the ability to become a bootable disk for a CoCo, Dragon or MM/1.
 
+#### Examples
+
+* **Local files example:**
+  ```bash
+  os9 gen -b=OS9Boot -t=customtrack.bin new.dsk
+  ```
+  Copies the standalone boot file (`OS9Boot`) and kernel track file (`customtrack.bin`) from your host system and writes them directly into `new.dsk`.
+
+* **Files inside an image example:**
+  ```bash
+  os9 gen -b=disk.dsk,folder/MyBootFile -t=disk.dsk,folder/ts.bin new.dsk
+  ```
+  Extracts the boot file and kernel track file located *inside* an existing disk image (`disk.dsk`), then writes them into `new.dsk`.
+
+* **Default paths example:**
+  ```bash
+  os9 gen -b=disk.dsk, -t=disk.dsk, new.dsk
+  ```
+  Uses the standard default boot and track file locations inside `disk.dsk` to prepare `new.dsk` for booting.
+  
 ---
 
 <h3 id="id">ID - Display sector 0 of an image</h3>

--- a/librbf/librbfseek.c
+++ b/librbf/librbfseek.c
@@ -27,7 +27,14 @@ error_code _os9_seek(os9_path_id path, int pos, int mode)
 			}
 		}
 
-		fseek(path->fd, pos, mode);
+		if (fseek(path->fd, pos, mode) == 0)
+		{
+			path->filepos = ftell(path->fd);
+		}
+		else
+		{
+			ec = -1; /* Return failure code if fseek failed */
+		}
 	}
 	else
 	{
@@ -63,7 +70,7 @@ error_code _os9_seek(os9_path_id path, int pos, int mode)
 int _os9_lsn_fseek(os9_path_id path, int lsn)
 {
 	long offset;
-
+	
 	if (lsn >= path->t0s)
 	{
 		/* Skip past missing sectors */

--- a/librbf/librbfseek.c
+++ b/librbf/librbfseek.c
@@ -70,7 +70,7 @@ error_code _os9_seek(os9_path_id path, int pos, int mode)
 int _os9_lsn_fseek(os9_path_id path, int lsn)
 {
 	long offset;
-	
+
 	if (lsn >= path->t0s)
 	{
 		/* Skip past missing sectors */

--- a/os9/os9gen.c
+++ b/os9/os9gen.c
@@ -22,6 +22,8 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 		     char *trackfile, struct personality *hwtype,
 		     int extended);
 
+error_code get_boottrack_lsn(lsn0_sect LSN0, struct personality *hwtype, int *startlsn);
+
 static struct personality coco = { 18 * 34 };
 static struct personality dragon = { 2 };
 
@@ -159,7 +161,6 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
     error_code ec = 0;
     coco_path_id opath = NULL, cpath = NULL;
     char buffer[256];
-    lsn0_sect LSN0;
     u_int size;
     u_int sectors;
 
@@ -171,8 +172,6 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
         char boottrack[(256 * 18) + 1];
         u_int boottrack_len = 0;
         _path_type track_type = NATIVE;
-		int is_osk;
-		u_char *pd_sct, *pd_cyl, *pd_sid, *pd_typ;
 		int startlsn;
 
         _coco_identify_image(trackfile, &track_type);
@@ -184,38 +183,25 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
             ec = _coco_open(&cpath, buffer, FAM_READ);
             if (ec != 0)
             {
-                fprintf(stderr, "%s: error %d opening track image '%s'\n", argv[0], ec, buffer);
+                fprintf(stderr, "%s: error %d opening trackfile image '%s'\n", argv[0], ec, buffer);
+                return (1);
+            }
+			
+			if (cpath->type != OS9)
+            {
+                fprintf(stderr, "%s: error extracting trackfile from image '%s'\n", argv[0], buffer);
                 return (1);
             }
 
-            /* Read LSN0 to determine image geometry */
-            lsn0_sect track_LSN0;
-            size = sizeof(lsn0_sect);
-            ec = _coco_read(cpath, &track_LSN0, &size);
-            if (ec != 0) return ec;
-
-            u_int total_sectors = int3(track_LSN0.dd_tot);
-            int t34_sct = int2(track_LSN0.dd_opt.m6809.pd_sct);
-            int t34_sid = int1(track_LSN0.dd_opt.m6809.pd_sid);
-
-            /* Fallback to default CoCo 18 sectors/track if uninitialized */
-            if (t34_sct == 0) t34_sct = 18;
-
-            /* If pd_sid is uninitialized, deduce side count from total sectors */
-            if (t34_sid == 0)
-            {
-                /* 35 trk * 18 sct = 630 (1-sided), 1260 (2-sided) */
-                /* 40 trk * 18 sct = 720 (1-sided), 1440 (2-sided) */
-                /* 80 trk * 18 sct = 1440 (1-sided), 2880 (2-sided) */
-                t34_sid = (total_sectors > 720 && (total_sectors % (t34_sct * 2) == 0)) ? 2 : 1;
-            }
-
-            /* Calculate exact LSN for Track 34 Side 0 */
-            int sectors_per_cylinder = t34_sct * t34_sid;
-            int embed_lsn = (hwtype->startlsn == 2) ? 2 : (34 * sectors_per_cylinder);
-
+			ec = get_boottrack_lsn(*cpath->path.os9->lsn0, hwtype, &startlsn);
+			if (ec != 0)
+			{
+				_coco_close(cpath);
+				return 1;
+			}
+			
             /* Seek to Track 34 and verify header */
-            ec = _coco_seek(cpath, embed_lsn * 256, SEEK_SET);
+            ec = _coco_seek(cpath, startlsn * 256, SEEK_SET);
             if (ec != 0) return ec;
             size = 2;
             char track_hdr[2];
@@ -223,15 +209,15 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 
             if (ec == 0 && track_hdr[0] == 'O' && track_hdr[1] == 'S')
             {
-                printf("Using embedded kernel trackfile code found at LSN %d of image '%s'\n", embed_lsn, trackfile);
-                _coco_seek(cpath, embed_lsn * 256, SEEK_SET);
+                printf("Using embedded kernel trackfile code found at LSN %d of image '%s'\n", startlsn, trackfile);
+                _coco_seek(cpath, startlsn * 256, SEEK_SET);
                 boottrack_len = 256 * 18;
                 _coco_read(cpath, boottrack, &boottrack_len);
             }
             else
             {
                 fprintf(stderr, "%s: image '%s' does not contain valid OS kernel trackfile code (0x%02x%02x) at LSN %d\n",
-                	argv[0], trackfile, track_hdr[0], track_hdr[1], embed_lsn);
+                	argv[0], trackfile, track_hdr[0], track_hdr[1], startlsn);
                 _coco_close(cpath);
                 return (1);
             }
@@ -276,90 +262,21 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
             return (1);
         }
 
-        /* Read target LSN0 to get cluster size and sector size */
-        size = sizeof(lsn0_sect);
-        _coco_read(opath, &LSN0, &size);
-
-		is_osk = (memcmp(LSN0.dd_sync, "Cruz", 4) == 0);
-
-		if (is_osk != 0)
+		if (opath->type != OS9)
 		{
-			pd_sct = LSN0.dd_opt.m68k.pd_sct;
-			pd_cyl = LSN0.dd_opt.m68k.pd_cyl;
-			pd_sid = LSN0.dd_opt.m68k.pd_sid;
-			pd_typ = LSN0.dd_opt.m68k.pd_typ;
-		}
-		else
-		{
-			pd_sct = LSN0.dd_opt.m6809.pd_sct;
-			pd_cyl = LSN0.dd_opt.m6809.pd_cyl;
-			pd_sid = LSN0.dd_opt.m6809.pd_sid;
-			pd_typ = LSN0.dd_opt.m6809.pd_typ;
+			fprintf(stderr, "%s: '%s' target needs to be OS9 image\n", argv[0], buffer);
+			_coco_close(opath);
+			return (1);
 		}
 
-		startlsn = hwtype->startlsn;
-
-		if (startlsn == 2)
+		ec = get_boottrack_lsn(*opath->path.os9->lsn0, hwtype, &startlsn);
+		if (ec != 0)
 		{
-			printf("Dragon boottrack selected: ");
-			/* Check to make sure the disk image has minimum of 18 sectors per track */
-			if (int2(pd_sct) < 18)
-			{
-				printf("\n");
-				fprintf(stderr,
-					"Error: minimum sectors per track of 18 required for DragonDOS, found %d\n",
-					int2(pd_sct));
-				_coco_close(opath);
-				return (1);
-			}
+			_coco_close(opath);
+			return 1;
 		}
-		else
-		{
-			printf("CoCo boottrack selected: ");
-			/* If special startLSN for boottrack is set then set startlsn to  */
-			/* the value stored in specialStartLSN  */
-			if (specialStartLSN > 0)
-			{
-				startlsn = specialStartLSN;
-			}
-			else
-			{
-				/* Check to see if disk image is a HDD image if so set for default  */
-				/* startLSN of 612 for the boottrack for use with CoCoSDC and DriveWire HDD images */
-				if (int1(pd_typ) == 0x80)
-				{
-					startlsn = 612;
-				}
-				else
-				{
-					/* Check to make sure the disk image has minimum of 18 sectors per track */
-					if (int2(pd_sct) < 18)
-					{
-						printf("\n");
-						fprintf(stderr,
-							"Error: minimum sectors per track of 18 required for Disk Basic, found %d\n",
-							int2(pd_sct));
-						_coco_close(opath);
-						return (1);
-					}
-					/* Check to make sure the disk image has minimum of 35 tracks */
-					if (int2(pd_cyl) < 35)
-					{
-						printf("\n");
-						fprintf(stderr,
-							"Error: minimum number of tracks required for Disk Basic is 35, found %d\n",
-							int2(pd_cyl));
-						_coco_close(opath);
-						return (1);
-					}
-					/* Use real floppy disk geometry to figure out real startLSN for boottrack */
-					startlsn =
-						34 * int2(pd_sct) *
-						int1(pd_sid);
-				}
-			}
-		}
-		if ((startlsn + 18) > int3(LSN0.dd_tot))
+				
+		if ((startlsn + 18) > int3(opath->path.os9->lsn0->dd_tot))
 		{
 			printf("\n");
 			fprintf(stderr,
@@ -369,13 +286,11 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 		}
 
 		u_int sectorSize = opath->path.os9->bps;
-		u_int clusterSize = int2(LSN0.dd_bit);
+		u_int clusterSize = int2(opath->path.os9->lsn0->dd_bit);
 
         /* Write boot track data out to target using actual read length */
-        fprintf(stderr, "calculated seek: %d\n", startlsn * 256 );
         _coco_seek(opath, startlsn * 256, SEEK_SET);
         size = boottrack_len;
-        fprintf(stderr, "ftell: %ld\n", ftell(opath->path.os9->fd) );
         _coco_write(opath, boottrack, &size);
 
         sectors = (size + sectorSize - 1) / sectorSize;
@@ -423,7 +338,7 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
         {
             _coco_close(cpath);
             fprintf(stderr, "could not generate absolute boot file name\n");
-            return (-1);
+            return (EOS_MF);
         }
 
 		coco_file_stat fstat = { 0 };
@@ -431,10 +346,19 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
         ec = _coco_create(&opath, buffer, FAM_WRITE, &fstat);
         if (ec != 0)
         {
+            _coco_close(opath);
             _coco_close(cpath);
             fprintf(stderr, "%s: error %d creating '%s'\n", argv[0], ec, buffer);
             return (ec);
         }
+
+		if (opath->type != OS9)
+		{
+			fprintf(stderr, "%s: '%s' target needs to be OS9 image\n", argv[0], buffer);
+            _coco_close(opath);
+            _coco_close(cpath);
+			return (1);
+		}
 
         /* Stream copy from source to target */
         char ioBuf[8192];
@@ -480,33 +404,114 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
             return (ec);
         }
 
-        size = sizeof(lsn0_sect);
-        _coco_read(opath, &LSN0, &size);
-
-        if (size != sizeof(lsn0_sect))
-        {
+		if (opath->type != OS9)
+		{
+			fprintf(stderr, "%s: '%s' target needs to be OS9 image\n", argv[0], buffer);
             _coco_close(opath);
-            printf("Error reading LSN0\n");
-            return (1);
-        }
+			return (1);
+		}
 
         if (extended == 0 || (bootfile_Size < 65536 && is_single_segment(fdbuf)))
         {
-            _int3(bootfile_Data, LSN0.dd_bt);
-            _int2(bootfile_Size, LSN0.dd_bsz);
+            _int3(bootfile_Data, opath->path.os9->lsn0->dd_bt);
+            _int2(bootfile_Size, opath->path.os9->lsn0->dd_bsz);
         }
         else
         {
-            _int3(bootfile_LSN, LSN0.dd_bt);
-            _int2(0, LSN0.dd_bsz);
+            _int3(bootfile_LSN, cpath->path.os9->lsn0->dd_bt);
+            _int2(0, opath->path.os9->lsn0->dd_bsz);
         }
 
         _coco_seek(opath, 0, SEEK_SET);
-        _coco_write(opath, &LSN0, &size);
+        size = sizeof(lsn0_sect);
+        _coco_write(opath, opath->path.os9->lsn0, &size);
         _coco_close(opath);
 
         printf("Bootfile Linked! LSN: %d, size: %d\n", bootfile_LSN, bootfile_Size);
     }
 
     return (0);
+}
+
+error_code get_boottrack_lsn(lsn0_sect LSN0, struct personality *hwtype, int *startlsn)
+{
+	int is_osk;
+	u_char *pd_sct, *pd_cyl, *pd_sid, *pd_typ;
+
+	is_osk = (memcmp(LSN0.dd_sync, "Cruz", 4) == 0);
+
+	if (is_osk != 0)
+	{
+		pd_sct = LSN0.dd_opt.m68k.pd_sct;
+		pd_cyl = LSN0.dd_opt.m68k.pd_cyl;
+		pd_sid = LSN0.dd_opt.m68k.pd_sid;
+		pd_typ = LSN0.dd_opt.m68k.pd_typ;
+	}
+	else
+	{
+		pd_sct = LSN0.dd_opt.m6809.pd_sct;
+		pd_cyl = LSN0.dd_opt.m6809.pd_cyl;
+		pd_sid = LSN0.dd_opt.m6809.pd_sid;
+		pd_typ = LSN0.dd_opt.m6809.pd_typ;
+	}
+
+	*startlsn = hwtype->startlsn;
+
+	if (*startlsn == 2)
+	{
+		printf("Dragon boottrack selected: ");
+		/* Check to make sure the disk image has minimum of 18 sectors per track */
+		if (int2(pd_sct) < 18)
+		{
+			printf("\n");
+			fprintf(stderr,
+				"Error: minimum sectors per track of 18 required for DragonDOS, found %d\n",
+				int2(pd_sct));
+			return (1);
+		}
+	}
+	else
+	{
+		printf("CoCo boottrack selected: ");
+		/* If special startLSN for boottrack is set then set startlsn to  */
+		/* the value stored in specialStartLSN  */
+		if (specialStartLSN > 0)
+		{
+			*startlsn = specialStartLSN;
+		}
+		else
+		{
+			/* Check to see if disk image is a HDD image if so set for default  */
+			/* startLSN of 612 for the boottrack for use with CoCoSDC and DriveWire HDD images */
+			if (int1(pd_typ) == 0x80)
+			{
+				*startlsn = 612;
+			}
+			else
+			{
+				/* Check to make sure the disk image has minimum of 18 sectors per track */
+				if (int2(pd_sct) < 18)
+				{
+					printf("\n");
+					fprintf(stderr,
+						"Error: minimum sectors per track of 18 required for Disk Basic, found %d\n",
+						int2(pd_sct));
+					return (1);
+				}
+				/* Check to make sure the disk image has minimum of 35 tracks */
+				if (int2(pd_cyl) < 35)
+				{
+					printf("\n");
+					fprintf(stderr,
+						"Error: minimum number of tracks required for Disk Basic is 35, found %d\n",
+						int2(pd_cyl));
+					return (1);
+				}
+				/* Use real floppy disk geometry to figure out real startLSN for boottrack */
+				*startlsn = 34 * int2(pd_sct) * int1(pd_sid);
+			}
+		}
+	}
+	
+	return 0;
 }

--- a/os9/os9gen.c
+++ b/os9/os9gen.c
@@ -11,7 +11,7 @@
 #include <sys/stat.h>
 #include <cocotypes.h>
 #include <cocopath.h>
-
+#include <toolshed.h>
 
 struct personality
 {
@@ -153,56 +153,132 @@ int os9gen(int argc, char *argv[])
 #define is_single_segment(fd) (int3((fd).fd_seg[1].lsn) == 0)
 
 static int do_os9gen(char **argv, char *device, char *bootfile,
-		     char *trackfile, struct personality *hwtype,
-		     int extended)
+                     char *trackfile, struct personality *hwtype,
+                     int extended)
 {
-	error_code ec = 0;
-	os9_path_id opath;
-	coco_path_id cpath;
-	char buffer[256];
-	lsn0_sect LSN0;
-	u_int size;
-	u_int sectors;
-	u_int sectorSize;
-	u_int clusterSize;
+    error_code ec = 0;
+    coco_path_id opath = NULL, cpath = NULL;
+    char buffer[256];
+    lsn0_sect LSN0;
+    u_int size;
+    u_int sectors;
 
+    /* 1. If a boot track file was provided, process and write it first */
 
-	/* 1. If we have a boot track file, put it on the disk first */
-
-	if (trackfile != NULL)
-	{
-		int startlsn;
-		error_code ec;
-		char boottrack[256 * 18];
-		u_char *pd_sct, *pd_cyl, *pd_sid, *pd_typ;
+    if (trackfile != NULL)
+    {
+        /* Safe buffer size for (256 * 18) + 1 test byte */
+        char boottrack[(256 * 18) + 1];
+        u_int boottrack_len = 0;
+        _path_type track_type = NATIVE;
 		int is_osk;
+		u_char *pd_sct, *pd_cyl, *pd_sid, *pd_typ;
+		int startlsn;
 
+        _coco_identify_image(trackfile, &track_type);
 
-		/* 1. Open the device raw and read LSB0 */
+        if (track_type == OS9 && TSIsDirectory(trackfile))
+        {
+            /* Trackfile is an OS-9 disk image container — extract Track 34 */
+            snprintf(buffer, sizeof(buffer), "%s,@", trackfile);
+            ec = _coco_open(&cpath, buffer, FAM_READ);
+            if (ec != 0)
+            {
+                fprintf(stderr, "%s: error %d opening track image '%s'\n", argv[0], ec, buffer);
+                return (1);
+            }
 
-		ec = snprintf(buffer, sizeof(buffer), "%s,@", device);
-		if (ec >= sizeof(buffer))
-		{
-			fprintf(stderr, "could not generate raw device pathname\n");
-			return (1);
-		}
+            /* Read LSN0 to determine image geometry */
+            lsn0_sect track_LSN0;
+            size = sizeof(lsn0_sect);
+            ec = _coco_read(cpath, &track_LSN0, &size);
+            if (ec != 0) return ec;
 
-		ec = _os9_open(&opath, buffer, FAM_READ | FAM_WRITE);
+            u_int total_sectors = int3(track_LSN0.dd_tot);
+            int t34_sct = int2(track_LSN0.dd_opt.m6809.pd_sct);
+            int t34_sid = int1(track_LSN0.dd_opt.m6809.pd_sid);
 
-		if (ec != 0)
-		{
-			fprintf(stderr, "%s: error %d opening '%s'\n",
-				argv[0], ec, buffer);
-			return 1;
-		}
+            /* Fallback to default CoCo 18 sectors/track if uninitialized */
+            if (t34_sct == 0) t34_sct = 18;
 
-		sectorSize = opath->bps;
+            /* If pd_sid is uninitialized, deduce side count from total sectors */
+            if (t34_sid == 0)
+            {
+                /* 35 trk * 18 sct = 630 (1-sided), 1260 (2-sided) */
+                /* 40 trk * 18 sct = 720 (1-sided), 1440 (2-sided) */
+                /* 80 trk * 18 sct = 1440 (1-sided), 2880 (2-sided) */
+                t34_sid = (total_sectors > 720 && (total_sectors % (t34_sct * 2) == 0)) ? 2 : 1;
+            }
 
-		size = sizeof(lsn0_sect);
+            /* Calculate exact LSN for Track 34 Side 0 */
+            int sectors_per_cylinder = t34_sct * t34_sid;
+            int embed_lsn = (hwtype->startlsn == 2) ? 2 : (34 * sectors_per_cylinder);
 
-		_os9_read(opath, &LSN0, &size);
+            /* Seek to Track 34 and verify header */
+            ec = _coco_seek(cpath, embed_lsn * 256, SEEK_SET);
+            if (ec != 0) return ec;
+            size = 2;
+            char track_hdr[2];
+            ec = _coco_read(cpath, track_hdr, &size);
 
-		clusterSize = int2(LSN0.dd_bit);
+            if (ec == 0 && track_hdr[0] == 'O' && track_hdr[1] == 'S')
+            {
+                printf("Using embedded kernel trackfile code found at LSN %d of image '%s'\n", embed_lsn, trackfile);
+                _coco_seek(cpath, embed_lsn * 256, SEEK_SET);
+                boottrack_len = 256 * 18;
+                _coco_read(cpath, boottrack, &boottrack_len);
+            }
+            else
+            {
+                fprintf(stderr, "%s: image '%s' does not contain valid OS kernel trackfile code (0x%02x%02x) at LSN %d\n",
+                	argv[0], trackfile, track_hdr[0], track_hdr[1], embed_lsn);
+                _coco_close(cpath);
+                return (1);
+            }
+            _coco_close(cpath);
+        }
+        else
+        {
+            /* Standalone trackfile — open and read up to 4609 bytes to check size */
+            ec = _coco_open(&cpath, trackfile, FAM_READ);
+            if (ec != 0)
+            {
+                fprintf(stderr, "%s: error %d opening kernel trackfile '%s'\n", argv[0], ec, trackfile);
+                return (1);
+            }
+
+            boottrack_len = (256 * 18) + 1;
+            ec = _coco_read(cpath, boottrack, &boottrack_len);
+
+            if (boottrack_len > (256 * 18))
+            {
+                fprintf(stderr, "%s: kernel trackfile '%s' exceeds 18 sectors (4608 bytes)\n", argv[0], trackfile);
+                _coco_close(cpath);
+                return (1);
+            }
+
+            if (ec != 0 && ec != EOS_EOF)
+            {
+                fprintf(stderr, "%s: error %d reading kernel trackfile '%s'\n", argv[0], ec, trackfile);
+                _coco_close(cpath);
+                return (1);
+            }
+
+            _coco_close(cpath);
+        }
+
+        /* Open target device raw to write the kernel trackfile */
+        snprintf(buffer, sizeof(buffer), "%s,@", device);
+        ec = _coco_open(&opath, buffer, FAM_READ | FAM_WRITE);
+        if (ec != 0)
+        {
+            fprintf(stderr, "%s: error %d opening target device '%s'\n", argv[0], ec, buffer);
+            return (1);
+        }
+
+        /* Read target LSN0 to get cluster size and sector size */
+        size = sizeof(lsn0_sect);
+        _coco_read(opath, &LSN0, &size);
 
 		is_osk = (memcmp(LSN0.dd_sync, "Cruz", 4) == 0);
 
@@ -221,15 +297,7 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 			pd_typ = LSN0.dd_opt.m6809.pd_typ;
 		}
 
-		/*  Diagnostic output */
-
-		/* printf("Sectors per track: %d, Heads: %d, Disk Type: %d, Total Sectors: %d \n", int2(pd_sct), int1(pd_sid), int1(pd_typ), int3(LSN0.dd_tot)); */
-
-		/* 2. Determine startlsn based on single or double-sided device */
-
 		startlsn = hwtype->startlsn;
-
-		/* printf("hardware type: %d\n", startlsn); */
 
 		if (startlsn == 2)
 		{
@@ -241,7 +309,7 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 				fprintf(stderr,
 					"Error: minimum sectors per track of 18 required for DragonDOS, found %d\n",
 					int2(pd_sct));
-				_os9_close(opath);
+				_coco_close(opath);
 				return (1);
 			}
 		}
@@ -271,7 +339,7 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 						fprintf(stderr,
 							"Error: minimum sectors per track of 18 required for Disk Basic, found %d\n",
 							int2(pd_sct));
-						_os9_close(opath);
+						_coco_close(opath);
 						return (1);
 					}
 					/* Check to make sure the disk image has minimum of 35 tracks */
@@ -281,7 +349,7 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 						fprintf(stderr,
 							"Error: minimum number of tracks required for Disk Basic is 35, found %d\n",
 							int2(pd_cyl));
-						_os9_close(opath);
+						_coco_close(opath);
 						return (1);
 					}
 					/* Use real floppy disk geometry to figure out real startLSN for boottrack */
@@ -296,178 +364,149 @@ static int do_os9gen(char **argv, char *device, char *bootfile,
 			printf("\n");
 			fprintf(stderr,
 				"Error: start LSN puts boottrack outside of OS-9 volume boundery\n");
-			_os9_close(opath);
+			_coco_close(opath);
 			return (1);
 		}
 
-		/* 3. Open the track file */
+		u_int sectorSize = opath->path.os9->bps;
+		u_int clusterSize = int2(LSN0.dd_bit);
 
-		ec = _coco_open(&cpath, trackfile, FAM_READ);
+        /* Write boot track data out to target using actual read length */
+        fprintf(stderr, "calculated seek: %d\n", startlsn * 256 );
+        _coco_seek(opath, startlsn * 256, SEEK_SET);
+        size = boottrack_len;
+        fprintf(stderr, "ftell: %ld\n", ftell(opath->path.os9->fd) );
+        _coco_write(opath, boottrack, &size);
 
-		if (ec != 0)
-		{
-			fprintf(stderr, "%s: error %d opening '%s'\n",
-				argv[0], ec, trackfile);
-			_os9_close(opath);
-			return (1);
-		}
+        sectors = (size + sectorSize - 1) / sectorSize;
+        _os9_allbit(opath->path.os9->bitmap,
+                    (startlsn + clusterSize - 1) / clusterSize,
+                    (sectors + clusterSize - 1) / clusterSize);
 
+        printf("Kernel trackfile written! LSN: %d, size: %d\n", startlsn, size);
+        _coco_close(opath);
+    }
 
-		/* 4. Read the track file. */
+    /* 2. Process and write OS9Boot to target disk */
 
-		size = 256 * 18;
-		_coco_read(cpath, boottrack, &size);
+    if (bootfile != NULL)
+    {
+        _path_type boot_type = NATIVE;
+        char bootfile_path[512];
 
-		_coco_close(cpath);
+        _coco_identify_image(bootfile, &boot_type);
 
-		/* 5. Seek to appropriate track and write out track data. */
+        /* Case A: Source is an OS-9 disk image container — default to reading ',OS9Boot' */
+        if (boot_type == OS9 && TSIsDirectory(bootfile))
+        {
+            snprintf(bootfile_path, sizeof(bootfile_path), "%s,OS9Boot", bootfile);
+            printf("Extracting 'OS9Boot' from disk image '%s'\n", bootfile);
+        }
+        else
+        {
+            /* Case B: Standalone host file or already fully-qualified path */
+            strncpy(bootfile_path, bootfile, sizeof(bootfile_path) - 1);
+            bootfile_path[sizeof(bootfile_path) - 1] = '\0';
+        }
 
-		_os9_seek(opath, startlsn * 256, SEEK_SET);
+        /* Let _coco_open handle opening the file (works for contiguous or discontiguous) */
+        ec = _coco_open(&cpath, bootfile_path, FAM_READ);
+        if (ec != 0)
+        {
+            fprintf(stderr, "%s: error %d opening bootfile '%s'\n", argv[0], ec, bootfile_path);
+            return (1);
+        }
 
-		_os9_write(opath, boottrack, &size);
+        /* Create target 'OS9Boot' on destination device */
+        ec = snprintf(buffer, sizeof(buffer), "%s,OS9Boot", device);
+        if (ec >= sizeof(buffer))
+        {
+            _coco_close(cpath);
+            fprintf(stderr, "could not generate absolute boot file name\n");
+            return (-1);
+        }
 
+		coco_file_stat fstat = { 0 };
+		fstat.perms = FAP_READ | FAP_WRITE;
+        ec = _coco_create(&opath, buffer, FAM_WRITE, &fstat);
+        if (ec != 0)
+        {
+            _coco_close(cpath);
+            fprintf(stderr, "%s: error %d creating '%s'\n", argv[0], ec, buffer);
+            return (ec);
+        }
 
-		/* TODO: Deallocate appropriate bits in bitmap sector */
-		/* Is not necesary on Dragon, but wouldn't harm */
+        /* Stream copy from source to target */
+        char ioBuf[8192];
+        for (;;)
+        {
+            u_int n = sizeof(ioBuf);
+            ec = _coco_read(cpath, ioBuf, &n);
+            if (ec == EOS_EOF || n == 0) break;
+            if (ec != 0)
+            {
+                fprintf(stderr, "%s: error %d reading '%s'\n", argv[0], ec, bootfile_path);
+                _coco_close(cpath);
+                _coco_close(opath);
+                return (ec);
+            }
+            _coco_write(opath, ioBuf, &n);
+        }
 
-		sectors = (size + sectorSize - 1) / sectorSize;
-		_os9_allbit(opath->bitmap,
-			    (startlsn + clusterSize - 1) / clusterSize,
-			    (sectors + clusterSize - 1) / clusterSize);
+        _coco_close(cpath);
 
-		printf("Boot track written!  LSN: %d, size: %d\n", startlsn,
-		       size);
+        /* Read FD stats of created OS9Boot file to link into target device's LSN0 */
+        fd_stats fdbuf;
+        _os9_gs_fd(opath->path.os9, sizeof(fdbuf), &fdbuf);
 
-		_os9_close(opath);
-	}
+        if (!is_single_segment(fdbuf) && extended == 0)
+        {
+            printf("Error: %s is fragmented\n", bootfile_path);
+            _coco_close(opath);
+            return (1);
+        }
 
+        int bootfile_Size = int4(fdbuf.fd_siz);
+        int bootfile_LSN = opath->path.os9->pl_fd_lsn;
+        int bootfile_Data = int3(fdbuf.fd_seg[0].lsn);
 
-	/* 2. Now put OS9Boot on disk */
+        _coco_close(opath);
 
-	if (bootfile != NULL)
-	{
-		fd_stats fdbuf;
-		int bootfile_LSN, bootfile_Size, bootfile_Data;
-		u_int size = sizeof(fdbuf);
+        /* Link OS9Boot into target device's LSN0 */
+        snprintf(buffer, sizeof(buffer), "%s,@", device);
+        ec = _coco_open(&opath, buffer, FAM_READ | FAM_WRITE);
+        if (ec != 0)
+        {
+            return (ec);
+        }
 
-		/* 2.1. Open a path to the bootfile */
+        size = sizeof(lsn0_sect);
+        _coco_read(opath, &LSN0, &size);
 
-		ec = _coco_open(&cpath, bootfile, FAM_READ);
+        if (size != sizeof(lsn0_sect))
+        {
+            _coco_close(opath);
+            printf("Error reading LSN0\n");
+            return (1);
+        }
 
-		if (ec != 0)
-		{
-			fprintf(stderr, "%s: error %d opening '%s'\n",
-				argv[0], ec, bootfile);
+        if (extended == 0 || (bootfile_Size < 65536 && is_single_segment(fdbuf)))
+        {
+            _int3(bootfile_Data, LSN0.dd_bt);
+            _int2(bootfile_Size, LSN0.dd_bsz);
+        }
+        else
+        {
+            _int3(bootfile_LSN, LSN0.dd_bt);
+            _int2(0, LSN0.dd_bsz);
+        }
 
-			return (1);
-		}
+        _coco_seek(opath, 0, SEEK_SET);
+        _coco_write(opath, &LSN0, &size);
+        _coco_close(opath);
 
-		/* 2.2. Create a file called 'OS9Boot' in the root dir of device */
-		ec = snprintf(buffer, sizeof(buffer), "%s,OS9Boot", device);
-		if (ec >= sizeof(buffer))
-		{
-			_coco_close(cpath);
-			fprintf(stderr, "could not generate absolute boot file name\n");
-			return (-1);
-		}
+        printf("Bootfile Linked! LSN: %d, size: %d\n", bootfile_LSN, bootfile_Size);
+    }
 
-		ec = _os9_create(&opath, buffer, FAM_WRITE, FAM_READ | FAM_WRITE);
-		if (ec != 0)
-		{
-			_coco_close(cpath);
-			fprintf(stderr, "Failed to allocate memory\n");
-			return (-1);
-		}
-
-		/* 2.3. Write out bootfile to path */
-
-		_os9_gs_fd(opath, sizeof(fdbuf), &fdbuf);
-
-		{
-			char ioBuf[8192];
-
-			for (;;)
-			{
-				u_int n = sizeof(ioBuf);
-
-				ec = _coco_read(cpath, ioBuf, &n);
-				if (ec == EOS_EOF)
-				{
-					break;
-				}
-				if (ec != 0) {
-					fprintf(stderr, "%s: error %d reading '%s'\n", argv[0], ec, bootfile);
-					_coco_close(cpath);
-					_os9_close(opath);
-					return (1);
-				}
-
-				ec = _os9_write(opath, ioBuf, &n);
-				if (ec != 0) 
-				{
-					fprintf(stderr, "%s: error %d writing OS9Boot\n", argv[0], ec);
-					_coco_close(cpath);
-					_os9_close(opath);
-					return (1);
-				}
-			}
-		}
-
-		_os9_gs_fd(opath, sizeof(fdbuf), &fdbuf);
-
-		if (!is_single_segment(fdbuf) && extended == 0)
-		{
-			printf("Error: %s is fragmented\n", bootfile);
-			_coco_close(cpath);
-			_os9_close(opath);
-			return (1);
-		}
-
-		bootfile_Size = int4(fdbuf.fd_siz);
-		bootfile_LSN = opath->pl_fd_lsn;
-		bootfile_Data = int3(fdbuf.fd_seg[0].lsn);
-
-		_coco_close(cpath);
-		_os9_close(opath);
-
-		/* Link the passed bootfile to LSN0 */
-
-		/* 3. Open a path to the device raw */
-		sprintf(buffer, "%s,@", device);
-
-		ec = _os9_open(&opath, buffer, FAM_READ | FAM_WRITE);
-		if (ec != 0)
-		{
-			return (ec);
-		}
-
-		size = sizeof(lsn0_sect);
-		_os9_read(opath, &LSN0, &size);
-
-		if (size != sizeof(lsn0_sect))
-		{
-			_os9_close(opath);
-			printf("Error reading LSN0\n");
-			return (1);
-		}
-
-		if (extended == 0 || (bootfile_Size < 65536 && is_single_segment(fdbuf)))
-		{
-			_int3(bootfile_Data, LSN0.dd_bt);
-			_int2(bootfile_Size, LSN0.dd_bsz);
-		}
-		else
-		{
-			_int3(bootfile_LSN, LSN0.dd_bt);
-			_int2(0, LSN0.dd_bsz);
-		}
-		_os9_seek(opath, 0, SEEK_SET);
-		_os9_write(opath, &LSN0, &size);
-		_os9_close(opath);
-
-		printf("Bootfile Linked!  LSN: %d, size: %d\n", bootfile_LSN,
-		       bootfile_Size);
-	}
-
-	return (0);
+    return (0);
 }


### PR DESCRIPTION
## Summary

This PR extends `os9 gen` to support using boot files and kernel track files directly from existing OS-9 disk images, while also refactoring and improving the boot track handling code.

## Changes

- Add support for using an OS-9 disk image as the source for the kernel track file (`-t`):
  - Automatically locate the boot track within the source image.
  - Validate that the embedded kernel track is present before copying.
  - Continue to support standalone kernel track files.

- Add support for using an OS-9 disk image as the source for `OS9Boot` (`-b`):
  - Automatically extract `OS9Boot` from the source image when a disk image is specified.
  - Continue to support standalone boot files.

- Refactor boot track location logic:
  - Move boot track LSN calculation into a new `get_boottrack_lsn()` helper.
  - Reuse the same logic for both reading and writing boot tracks, eliminating duplicated code.

- Improve robustness:
  - Verify boot track size before writing.
  - Improve validation and error reporting when opening or extracting boot files and track files.
  - Ensure target images are OS-9 images before attempting modifications.
  - Update `_os9_seek()` to track the current file position after a successful `fseek()` and return an error if `fseek()` fails.

- Documentation:
  - Add examples showing:
    - Using standalone host files.
    - Using boot and track files stored inside another OS-9 disk image.
    - Using the default `OS9Boot` and kernel track locations from an existing image.

## Benefits

- Makes it easy to clone the boot components from an existing bootable OS-9 disk image without manually extracting files first.
- Reduces duplicated code by centralizing boot track location logic.
- Improves error handling and internal consistency when manipulating OS-9 disk images.