### PR TITLE
Fix heap use-after-free in qDeleteLastNode and honor LDFLAGS in Makefiles

### DIFF
--- a/build/unix/ar2/Makefile
+++ b/build/unix/ar2/Makefile
@@ -9,7 +9,7 @@ BINARY	= ar2
 OBJS	= ar.o arsup.o lz1.o o2u.o
 
 $(BINARY)$(SUFEXE):	$(OBJS)
-	$(CC) $(OBJS) -o $@ $(DEBUG)
+	$(CC) $(LDFLAGS) $(OBJS) -o $@ $(DEBUG)
 
 $(OBJS):
 

--- a/build/unix/makewav/Makefile
+++ b/build/unix/makewav/Makefile
@@ -10,7 +10,7 @@ OBJS	= makewav.o
 LIBS	= -lm
 
 $(BINARY)$(SUFEXE):	$(OBJS)
-	$(CC) $(OBJS) $(LIBS) -o $@
+	$(CC) $(LDFLAGS) $(OBJS) -o $@ $(LIBS)
 
 clean:
 	$(RM) $(BINARY) $(BINARY).exe *.o

--- a/build/unix/rules.mak
+++ b/build/unix/rules.mak
@@ -8,11 +8,12 @@ RM			= rm -f
 INSTALL		= install
 MAKE		= make
 CFLAGS		= -Dunix -DUNIX -O3 -I. -I../../../include -Wall -DTOOLSHED_VERSION=\"$(VERSION)\" -D_FILE_OFFSET_BITS=64 -Wno-unused-result -Werror
-#CFLAGS		+= -g -O0
+#CFLAGS		+= -g -O0 -fsanitize=address -Wno-error=deprecated-declarations
 ASM			= rma
 AR			= $(CROSS)ar
 RANLIB		= $(CROSS)ranlib
 CC			= $(CROSS)cc
+#LDFLAGS     += -fsanitize=address
 
 ifneq ($(WIN),)
 SUFEXE		= .exe

--- a/libmisc/libmiscqueue.c
+++ b/libmisc/libmiscqueue.c
@@ -139,28 +139,40 @@ int qDeleteNode(NodeType * head, NodeType targetNode)
 
 int qDeleteLastNode(NodeType * head)
 {
-	NodeType p = *head;
-	NodeType prev = *head;
+	NodeType p;
+	NodeType prev = NULL;
 
-	/* take 1st case where queue is empty */
-	if (p == NULL)
+	/* 1. Guard against invalid pointer or empty queue */
+	if (head == NULL || *head == NULL)
 	{
 		return 0;
 	}
-	/* walk queue to find last node */
-	while (p != NULL)
+
+	p = *head;
+
+	/* 2. Walk queue to find last node and its predecessor */
+	while (p->next != NULL)
 	{
-		if (p->next == NULL)
-		{
-			break;
-		}
 		prev = p;
 		p = p->next;
 	}
 
+	/* 3. Update the pointers FIRST while memory is valid */
+	if (prev != NULL)
+	{
+		/* Case A: Queue has 2 or more nodes */
+		prev->next = NULL;
+	}
+	else
+	{
+		/* Case B: Queue has only 1 node — head becomes NULL */
+		*head = NULL;
+	}
+
+	/* 4. Free the node memory LAST */
 	free(p->data);
 	free(p);
-	prev->next = NULL;
+
 	return 0;
 }
 


### PR DESCRIPTION
Summary
Fixes a heap memory corruption issue caused by a use-after-free bug in qDeleteLastNode(), and updates Unix build recipes to respect LDFLAGS.

Root Cause
When popping the final remaining node off a queue in qDeleteLastNode(), p and prev point to the exact same memory block (*head).

The function called free(p) before writing prev->next = NULL, which resulted in a heap use-after-free write on the deallocated pointer. In addition, when clearing a single-element queue, *head was left pointing to freed memory rather than being set to NULL. This corrupted heap metadata and manifested down the line as malloc / strdup failures during path processing.