### PR TITLE
Static runtime

### DIFF
--- a/.github/workflows/diskshed.yml
+++ b/.github/workflows/diskshed.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: wx-install
-          key: wxwidgets-${{ env.WX_VERSION }}-${{ runner.os }}-mingw64-static
+          key: wxwidgets-${{ env.WX_VERSION }}-${{ runner.os }}-mingw64-static-1
       - name: Build wxWidgets
         shell: msys2 {0}
         run: |
@@ -105,6 +105,7 @@ jobs:
             cmake -S "wxWidgets-${WX_VERSION}" -B wx-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="$PWD/wx-install" \
+              -DwxBUILD_USE_STATIC_RUNTIME=ON \
               -DwxBUILD_SHARED=OFF \
               -DwxBUILD_SAMPLES=OFF \
               -DwxBUILD_TESTS=OFF \

--- a/gui/wx/CMakeLists.txt
+++ b/gui/wx/CMakeLists.txt
@@ -118,6 +118,7 @@ if(DISKSHED_BUILD_GUI)
                 MACOSX_PACKAGE_LOCATION "Resources")
             target_sources(diskshed PRIVATE ${DISKSHED_MAC_ICON})
         elseif(WIN32)
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
             set(DISKSHED_WINDOWS_ICON
                 "${CMAKE_CURRENT_SOURCE_DIR}/packaging/org.nitros9.diskshed.ico")
             configure_file(packaging/diskshed.rc.in diskshed.rc @ONLY)


### PR DESCRIPTION
Build DiskShed.exe for Windows without additional dlls, so it may run out-of-the-box like other tool shed tools.