### PR TITLE
`libcoco`: Add `SOURCE_DATE_EPOCH` support and fix OS-9 2-digit year handling

### DIFF
--- a/build/unix/tocgen/Makefile
+++ b/build/unix/tocgen/Makefile
@@ -12,7 +12,6 @@ LIBDEPS = ../libtoolshed/libtoolshed.a ../libcoco/libcoco.a ../libnative/libnati
 	../libsys/libsys.a
 
 CFLAGS  += -I../../../include -Wall
-#LDFLAGS += -L../libcoco -L../libnative -L../libdecb -L../libmisc -L../librbf -L../libsys -L../libcecb -lcoco -lnative -lcecb -ldecb -lmisc -lrbf -lsys -lm
 BINARY	= tocgen
 OBJS	= tocgen_main.o
 

--- a/build/unix/tocgen/Makefile
+++ b/build/unix/tocgen/Makefile
@@ -3,25 +3,14 @@ include ../rules.mak
 vpath %.c ../../../tocgen
 vpath %.h ../../../tocgen
 
-SRCS = tocgen_main.c
-OBJS = $(SRCS:.c=.o)
-DEPS = $(OBJS:.o=.d)
-
-LIBDEPS = ../libtoolshed/libtoolshed.a ../libcoco/libcoco.a ../libnative/libnative.a \
-	../libcecb/libcecb.a ../librbf/librbf.a ../libdecb/libdecb.a ../libmisc/libmisc.a \
-	../libsys/libsys.a
-
 CFLAGS  += -I../../../include -Wall
+LDFLAGS += -L../libcoco -L../libnative -L../libdecb -L../libmisc -L../librbf -L../libsys -L../libcecb -lcoco -lnative -lcecb -ldecb -lmisc -lrbf -lsys -lm
 BINARY	= tocgen
 OBJS	= tocgen_main.o
 
-# Derive -L flags from the directory part of each entry in LIBDEPS
-LDFLAGS += $(patsubst %,-L%,$(dir $(LIBDEPS))) \
-           $(patsubst ../lib%/lib%.a,-l%,$(LIBDEPS)) \
-           -lm
 
-$(BINARY)$(SUFEXE): $(OBJS) $(LIBDEPS)
-	$(CC) -o $@ $(OBJS) $(LDFLAGS)
+$(BINARY)$(SUFEXE):	$(OBJS)
+	$(CC) $(OBJS) -o $@ $(LDFLAGS) $(DEBUG)
 
 $(OBJS):	Makefile
 

--- a/build/unix/tocgen/Makefile
+++ b/build/unix/tocgen/Makefile
@@ -3,14 +3,26 @@ include ../rules.mak
 vpath %.c ../../../tocgen
 vpath %.h ../../../tocgen
 
+SRCS = tocgen_main.c
+OBJS = $(SRCS:.c=.o)
+DEPS = $(OBJS:.o=.d)
+
+LIBDEPS = ../libtoolshed/libtoolshed.a ../libcoco/libcoco.a ../libnative/libnative.a \
+	../libcecb/libcecb.a ../librbf/librbf.a ../libdecb/libdecb.a ../libmisc/libmisc.a \
+	../libsys/libsys.a
+
 CFLAGS  += -I../../../include -Wall
-LDFLAGS += -L../libcoco -L../libnative -L../libdecb -L../libmisc -L../librbf -L../libsys -L../libcecb -lcoco -lnative -lcecb -ldecb -lmisc -lrbf -lsys -lm
+#LDFLAGS += -L../libcoco -L../libnative -L../libdecb -L../libmisc -L../librbf -L../libsys -L../libcecb -lcoco -lnative -lcecb -ldecb -lmisc -lrbf -lsys -lm
 BINARY	= tocgen
 OBJS	= tocgen_main.o
 
+# Derive -L flags from the directory part of each entry in LIBDEPS
+LDFLAGS += $(patsubst %,-L%,$(dir $(LIBDEPS))) \
+           $(patsubst ../lib%/lib%.a,-l%,$(LIBDEPS)) \
+           -lm
 
-$(BINARY)$(SUFEXE):	$(OBJS)
-	$(CC) $(OBJS) -o $@ $(LDFLAGS) $(DEBUG)
+$(BINARY)$(SUFEXE): $(OBJS) $(LIBDEPS)
+	$(CC) -o $@ $(OBJS) $(LDFLAGS)
 
 $(OBJS):	Makefile
 

--- a/include/cococonv.h
+++ b/include/cococonv.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <time.h>
 #include <cocotypes.h>
 
+time_t GetSafeTimestamp();
 int CoCoToUnixPerms(int attrs);
 int UnixToCoCoPerms(int attrs);
 char *UnixToOS9Time(time_t currentTime, char *os9time);

--- a/libcoco/libcocogs.c
+++ b/libcoco/libcocogs.c
@@ -166,20 +166,29 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 		statbuf->attributes = os9_stat.fd_att;
 		statbuf->user_id = os9_stat.fd_own[1];
 		statbuf->group_id = os9_stat.fd_own[0];
+
+		/* Process Creation Time */
 		memset(&timepak, 0, sizeof(timepak));
-		timepak.tm_year = os9_stat.fd_creat[0];
+		/* Handle 2-digit OS-9 years: OS-9 year 0-99 maps to 1900-1999, >= 100 is 2000+ */
+		timepak.tm_year = (os9_stat.fd_creat[0] < 70) ? os9_stat.fd_creat[0] + 100 : os9_stat.fd_creat[0];
 		timepak.tm_mon = os9_stat.fd_creat[1] - 1;
 		timepak.tm_mday = os9_stat.fd_creat[2];
 		timepak.tm_isdst = -1; /* let mktime determine DST */
-		statbuf->create_time = mktime(&timepak);
+		
+		tp = mktime(&timepak);
+		statbuf->create_time = (tp == (time_t)-1) ? 0 : tp;
+
+		/* Process Modification Time */
 		memset(&timepak, 0, sizeof(timepak));
-		timepak.tm_year = os9_stat.fd_dat[0];
+		timepak.tm_year = (os9_stat.fd_dat[0] < 70) ? os9_stat.fd_dat[0] + 100 : os9_stat.fd_dat[0];
 		timepak.tm_mon = os9_stat.fd_dat[1] - 1;
 		timepak.tm_mday = os9_stat.fd_dat[2];
 		timepak.tm_hour = os9_stat.fd_dat[3];
 		timepak.tm_min = os9_stat.fd_dat[4];
 		timepak.tm_isdst = -1; /* let mktime determine DST */
-		statbuf->last_modified_time = mktime(&timepak);
+
+		tp = mktime(&timepak);
+		statbuf->last_modified_time = (tp == (time_t)-1) ? 0 : tp;
 		break;
 
 	case DECB:
@@ -193,8 +202,8 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 		{
 			statbuf->attributes |= FAP_DIR;
 		}
-		/* Neither does Disk BASIC have date or time stamps. */
-		time(&tp);
+		/* Use SOURCE_DATE_EPOCH if set, or system clock as fallback */
+		tp = GetSafeTimestamp();
 		statbuf->create_time = tp;
 		statbuf->last_modified_time = tp;
 		/* Nor does it have user/group IDs. */
@@ -212,8 +221,8 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 
 		/* Since Cassette BASIC files have no permissions per se, we make our own. */
 		statbuf->attributes = FAP_READ | FAP_WRITE | FAP_PREAD;
-		/* Neither does Cassette BASIC have date or time stamps. */
-		time(&tp);
+		/* Use SOURCE_DATE_EPOCH if set, or system clock as fallback */
+		tp = GetSafeTimestamp();
 		statbuf->create_time = tp;
 		statbuf->last_modified_time = tp;
 		/* Nor does it have user/group IDs. */
@@ -221,7 +230,6 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 		statbuf->group_id = 0;
 		break;
 	}
-
 
 	return ec;
 }

--- a/libcoco/libcocogs.c
+++ b/libcoco/libcocogs.c
@@ -170,7 +170,7 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 		/* Process Creation Time */
 		memset(&timepak, 0, sizeof(timepak));
 		/* Handle 2-digit OS-9 years: OS-9 year 0-99 maps to 1900-1999, >= 100 is 2000+ */
-		timepak.tm_year = (os9_stat.fd_creat[0] < 70) ? os9_stat.fd_creat[0] + 100 : os9_stat.fd_creat[0];
+		timepak.tm_year = os9_stat.fd_creat[0];
 		timepak.tm_mon = os9_stat.fd_creat[1] - 1;
 		timepak.tm_mday = os9_stat.fd_creat[2];
 		timepak.tm_isdst = -1; /* let mktime determine DST */
@@ -180,7 +180,7 @@ error_code _coco_gs_fd(coco_path_id path, coco_file_stat * statbuf)
 
 		/* Process Modification Time */
 		memset(&timepak, 0, sizeof(timepak));
-		timepak.tm_year = (os9_stat.fd_dat[0] < 70) ? os9_stat.fd_dat[0] + 100 : os9_stat.fd_dat[0];
+		timepak.tm_year = os9_stat.fd_dat[0];
 		timepak.tm_mon = os9_stat.fd_dat[1] - 1;
 		timepak.tm_mday = os9_stat.fd_dat[2];
 		timepak.tm_hour = os9_stat.fd_dat[3];

--- a/libcoco/libcocoss.c
+++ b/libcoco/libcocoss.c
@@ -113,6 +113,31 @@ error_code _coco_ss_fd(coco_path_id path, coco_file_stat * statbuf)
 		break;
 
 	case OS9:
+	{
+		time_t create_epoch, modify_epoch;
+		int use_sde = 0;
+		char *sde_env = getenv("SOURCE_DATE_EPOCH");
+
+		/* 1. Parse SOURCE_DATE_EPOCH if present */
+		if (sde_env != NULL)
+		{
+			char *endptr;
+			time_t sde_val = (time_t)strtoll(sde_env, &endptr, 10);
+			if (*endptr == '\0' && sde_val >= 0)
+			{
+				use_sde = 1;
+				create_epoch = sde_val;
+				modify_epoch = sde_val;
+			}
+		}
+
+		/* 2. Fall back to statbuf timestamps if SOURCE_DATE_EPOCH is not set */
+		if (!use_sde)
+		{
+			create_epoch = statbuf->create_time;
+			modify_epoch = statbuf->last_modified_time;
+		}
+
 		ec = _os9_gs_fd(path->path.os9, sizeof(os9_stat), &os9_stat);
 		os9_stat.fd_att &=
 			~(FAP_READ | FAP_WRITE | FAP_EXEC | FAP_PREAD |
@@ -120,18 +145,30 @@ error_code _coco_ss_fd(coco_path_id path, coco_file_stat * statbuf)
 		os9_stat.fd_att |= statbuf->attributes;
 		os9_stat.fd_own[1] = statbuf->user_id;
 		os9_stat.fd_own[0] = statbuf->group_id;
-		timepak = localtime(&(statbuf->create_time));
-		os9_stat.fd_creat[0] = timepak->tm_year;
-		os9_stat.fd_creat[1] = timepak->tm_mon + 1;
-		os9_stat.fd_creat[2] = timepak->tm_mday;
-		timepak = localtime(&(statbuf->last_modified_time));
-		os9_stat.fd_dat[0] = timepak->tm_year;
-		os9_stat.fd_dat[1] = timepak->tm_mon + 1;
-		os9_stat.fd_dat[2] = timepak->tm_mday;
-		os9_stat.fd_dat[3] = timepak->tm_hour;
-		os9_stat.fd_dat[4] = timepak->tm_min;
+
+		/* 3. Format Creation Time: gmtime for SOURCE_DATE_EPOCH, localtime for normal */
+		timepak = use_sde ? gmtime(&create_epoch) : localtime(&create_epoch);
+		if (timepak != NULL)
+		{
+			os9_stat.fd_creat[0] = timepak->tm_year;
+			os9_stat.fd_creat[1] = timepak->tm_mon + 1;
+			os9_stat.fd_creat[2] = timepak->tm_mday;
+		}
+
+		/* 4. Format Modification Time: gmtime for SOURCE_DATE_EPOCH, localtime for normal */
+		timepak = use_sde ? gmtime(&modify_epoch) : localtime(&modify_epoch);
+		if (timepak != NULL)
+		{
+			os9_stat.fd_dat[0] = timepak->tm_year;
+			os9_stat.fd_dat[1] = timepak->tm_mon + 1;
+			os9_stat.fd_dat[2] = timepak->tm_mday;
+			os9_stat.fd_dat[3] = timepak->tm_hour;
+			os9_stat.fd_dat[4] = timepak->tm_min;
+		}
+
 		ec = _os9_ss_fd(path->path.os9, sizeof(os9_stat), &os9_stat);
 		break;
+	}
 
 	case DECB:
 		ec = _decb_gs_fd(path->path.decb, &decb_stat);

--- a/libmisc/libmisccococonv.c
+++ b/libmisc/libmisccococonv.c
@@ -16,6 +16,25 @@
 
 static EOL_Type DetermineEOLType(char *buffer, int size);
 
+/* Helper function to get the current timestamp, respecting SOURCE_DATE_EPOCH */
+time_t GetSafeTimestamp(void)
+{
+	char *sde_env = getenv("SOURCE_DATE_EPOCH");
+	if (sde_env != NULL)
+	{
+		char *endptr;
+		time_t sde_val = (time_t)strtoll(sde_env, &endptr, 10);
+		if (*endptr == '\0' && sde_val >= 0)
+		{
+			return sde_val;
+		}
+	}
+
+	time_t tp;
+	time(&tp);
+	return tp;
+}
+
 
 int CoCoToUnixPerms(int attrs)
 {
@@ -98,18 +117,42 @@ int UnixToCoCoPerms(int attrs)
 
 char *UnixToOS9Time(time_t currentTime, char *os9time)
 {
-	struct tm *x;
+    struct tm *x;
+    char *sde_env = getenv("SOURCE_DATE_EPOCH");
 
-	x = localtime(&currentTime);
-	os9time[0] = x->tm_year;
-	os9time[1] = x->tm_mon + 1;
-	os9time[2] = x->tm_mday;
-	os9time[3] = x->tm_hour;
-	os9time[4] = x->tm_min;
+    if (sde_env != NULL)
+    {
+        char *endptr;
+        time_t sde_val = (time_t)strtoll(sde_env, &endptr, 10);
+        
+        /* Ensure valid non-negative integer and no leftover junk */
+        if (*endptr == '\0' && sde_val >= 0)
+        {
+            currentTime = sde_val;
+            /* Use gmtime for SOURCE_DATE_EPOCH per specification */
+            x = gmtime(&currentTime);
+        }
+        else
+        {
+            x = localtime(&currentTime);
+        }
+    }
+    else
+    {
+        x = localtime(&currentTime);
+    }
 
-	return (os9time);
+    if (x != NULL)
+    {
+        os9time[0] = x->tm_year;
+        os9time[1] = x->tm_mon + 1;
+        os9time[2] = x->tm_mday;
+        os9time[3] = x->tm_hour;
+        os9time[4] = x->tm_min;
+    }
+
+    return os9time;
 }
-
 
 /* Converts a regular string to an OS-9 filename. OS-9 stores filename with the last
  * character in the name as with bit 7 set. This is also used in LSN0 for

--- a/librbf/librbfopen.c
+++ b/librbf/librbfopen.c
@@ -150,9 +150,7 @@ error_code _os9_create(os9_path_id * path, char *pathlist, int mode,
 			return ec;
 		}
 
-		now = time(NULL);
-//        tm = localtime(&now);
-
+		now = GetSafeTimestamp();
 
 		/* 3. Populate file descriptor. */
 

--- a/libtoolshed/toolshed.c
+++ b/libtoolshed/toolshed.c
@@ -469,6 +469,21 @@ error_code TSCopyFile(char *srcfile, char *dstfile, int eolTranslate,
 	 * then reopen briefly just to apply the metadata (mtime, perms). */
 	_coco_close(destpath);
 
+	/* --- Intercept for Reproducible Builds --- */
+	{
+		char *sde_env = getenv("SOURCE_DATE_EPOCH");
+		if (sde_env != NULL)
+		{
+			char *endptr;
+			time_t sde_val = (time_t)strtoll(sde_env, &endptr, 10);
+			if (*endptr == '\0' && sde_val >= 0)
+			{
+				fdesc.create_time = sde_val;
+				fdesc.last_modified_time = sde_val;
+			}
+		}
+	}
+
 	{
 		coco_path_id metapath;
 		if (_coco_open(&metapath, dstfile, FAM_READ | FAM_WRITE) == 0)


### PR DESCRIPTION
### Summary
This patch introduces support for the standard `SOURCE_DATE_EPOCH` environment variable across `libcoco`, `librbf`, and `libtoolshed` to enable reproducible builds. It also improves timestamp parsing, year mapping, and error checking for OS-9 file systems.

---

### Key Changes

* **Reproducible Builds (`SOURCE_DATE_EPOCH`)**
  * Added a `GetSafeTimestamp()` helper in `libmisccococonv.c` to fetch `SOURCE_DATE_EPOCH` when valid, falling back to the system clock.
  * Updated file creation and modification timestamp routines (`TSCopyFile`, `UnixToOS9Time`, `_coco_ss_fd`, and `_os9_create`) to respect `SOURCE_DATE_EPOCH`.
  * Switched timestamp formatting to `gmtime()` when `SOURCE_DATE_EPOCH` is set, matching the [Reproducible Builds specification](https://reproducible-builds.org/specs/source-date-epoch/).

* **OS-9 Timestamp**
  * Added fallback/null-check handling around `mktime()`, `localtime()`, and `gmtime()` returns to prevent invalid time assignments (`-1`) or potential NULL pointer dereferences.