### PR TITLE
This PR fixes logic bugs in `cecb` cassette tape handling, properly r…

### DIFF
--- a/cecb/cecbbulkerase.c
+++ b/cecb/cecbbulkerase.c
@@ -91,7 +91,7 @@ int cecbbulkerase(int argc, char *argv[])
 		{
 			p = argv[i];
 
-			if (!strendcasecmp(argv[i], WAV_FILE_EXTENSION))
+			if (strendcasecmp(argv[i], WAV_FILE_EXTENSION))
 			{
 				printf("Skipping %s, not WAV file.\n", argv[i]);
 				continue;

--- a/include/toolshed.h
+++ b/include/toolshed.h
@@ -12,7 +12,7 @@ extern "C" {
 
 
 /* ERROR CODES */
-#define EOS_PADROM		257
+#define EOS_PADROM		258
 
 
 const char *TSReportError(error_code te);

--- a/include/util.h
+++ b/include/util.h
@@ -50,7 +50,7 @@ int StrToInt(char *s);
 int strcasecmp(char *s1, char *s2);
 int strncasecmp(char *s1, char *s2, int len);
 #endif
-int strendcasecmp( char *s1, char *s2 );
+int strendcasecmp(const char *s1, const char *s2);
 void show_help(char const * const *helpMessage);
 
 /* Function prototypes for supported Disk BASIC commands are here */

--- a/libcecb/libcecbopen.c
+++ b/libcecb/libcecbopen.c
@@ -274,13 +274,6 @@ error_code _cecb_open(cecb_path_id * path, char *pathlist, int mode)
 	else
 	{
 		(*path)->israw = 0;
-
-		/* If mode is FAM_DIR, then we need to error */
-		if (mode & FAM_DIR)
-		{
-			term_pd(*path);
-			return EOS_SN;
-		}
 	}
 
 	if (mode & FAM_RAW)
@@ -330,6 +323,8 @@ error_code _cecb_open(cecb_path_id * path, char *pathlist, int mode)
 
 	/* Find file */
 
+	int found = 0;
+	
 	while (ec == 0)
 	{
 		ec = _cecb_read_next_dir_entry(*path, &((*path)->dir_entry));
@@ -352,12 +347,15 @@ error_code _cecb_open(cecb_path_id * path, char *pathlist, int mode)
 				else if ((*path)->tape_type == WAV)
 					(*path)->wav_start_sample =
 						(*path)->wav_current_sample;
-
+				
+				found = 1;
 				break;
 			}
 		}
 	}
 
+	if (found == 0 ) ec = EOS_PNNF;
+	
 	return ec;
 }
 

--- a/libmisc/libmiscutil.c
+++ b/libmisc/libmiscutil.c
@@ -80,7 +80,7 @@ int StrToInt(char *s)
 	return (accum);
 }
 
-int strendcasecmp(char *s1, char *s2)
+int strendcasecmp(const char *s1, const char *s2)
 {
 	int a, b;
 

--- a/libtoolshed/toolshed.c
+++ b/libtoolshed/toolshed.c
@@ -28,6 +28,8 @@ const char *EOS_PTHFUL_str = "The file cannot be opened because the system path 
 const char *EOS_BMODE_str = "attempt to perform I/O function of which the device or file is incapable";
 const char *EOS_SF_str = "file is too fragmented to be expanded further";
 const char *EOS_SE_str = "physical seek to non-existant sector";
+const char *EOS_OM_str = "out of memory error";
+const char *EOS_SN_str = "syntax error";
 
 const char *TSReportError(error_code te)
 {
@@ -103,6 +105,14 @@ const char *TSReportError(error_code te)
 
 	case EOS_SE:
 		return EOS_SE_str;
+		break;
+
+	case EOS_OM:
+		return EOS_OM_str;
+		break;
+
+	case EOS_SN:
+		return EOS_SN_str;
 		break;
 
 	default:


### PR DESCRIPTION
## Summary
This PR fixes logic bugs in `cecb` cassette tape handling, properly reports missing file errors during `_cecb_open`, updates function signatures to use `const` qualifiers, and adds missing error string mappings to `libtoolshed`.

## Changes Included

* **Fix WAV extension validation in `cecbbulkerase`:** Inverted the check on `strendcasecmp` so that non-WAV files are correctly skipped rather than skipping valid WAV files.
* **Handle missing files in `_cecb_open`:** Added a `found` flag to `_cecb_open()` to ensure that reaching the end of a directory without finding the target file returns `EOS_PNNF` (*Path/File Not Found*).
* **Remove directory open restriction:** Removed the check returning `EOS_SN` when opening cassette paths with `FAM_DIR`.
* **Const correctness:** Updated `strendcasecmp` parameters in `util.h` and `libmiscutil.c` to accept `const char *`.
* **Error handling:** Added string lookup support for `EOS_OM` (*Out of memory*) and `EOS_SN` (*Syntax error*) in `TSReportError()`, and updated the `EOS_PADROM` definition in `toolshed.h`.

## How to Test
1. Run `cecbbulkerase` against a directory containing both WAV and non-WAV files to verify non-WAV files are skipped as intended.
2. Attempt to open a non-existent file on a CECB tape/image and confirm `EOS_PNNF` is returned.
3. Verify error messages print correctly for `EOS_OM` and `EOS_SN`.