### PR TITLE
 libcecb: Allow _cecb_create to create new cassette image files in write mode

### DIFF
--- a/libcecb/libcecbopen.c
+++ b/libcecb/libcecbopen.c
@@ -66,6 +66,11 @@ error_code _cecb_create(cecb_path_id * path, char *pathlist, int mode,
 
 	(*path)->fd = fopen((*path)->imgfile, open_mode);
 
+	if ((*path)->fd == NULL && (mode & FAM_WRITE))
+	{
+		(*path)->fd = fopen((*path)->imgfile, "wb+");
+	}
+
 	if ((*path)->fd == NULL)
 	{
 		term_pd(*path);
@@ -134,7 +139,12 @@ error_code _cecb_create(cecb_path_id * path, char *pathlist, int mode,
 		(*path)->cas_total_bytes = ftell((*path)->fd);
 
 		if ((*path)->play_at == LONG_MAX)
-			(*path)->play_at = ((*path)->cas_total_bytes * 8) - 1;
+		{
+			if ((*path)->cas_total_bytes == 0)
+				(*path)->play_at = 0;
+			else
+				(*path)->play_at = ((*path)->cas_total_bytes * 8) - 1;
+		}
 		
 		(*path)->cas_start_byte = (*path)->cas_current_byte = (*path)->play_at / 8;
 		(*path)->cas_start_bit = (*path)->cas_current_bit = 0x01 << ((*path)->play_at % 8);


### PR DESCRIPTION
## Description
This PR resolves an issue where running cecb copy (and building target .cas files in sub-projects such as hdbdos) fails with error 215 - badly formed pathname when copying files into a cassette image that does not yet exist on disk.

### Problem / Root Cause
1. File Opening Mode: In _cecb_create() (libcecb/libcecbopen.c), cassette image files were opened with fopen(imgfile, "rb+") when FAM_WRITE was set. In standard C I/O, "rb+" update mode fails and returns NULL if the file does not already exist on disk. This caused _cecb_create() to abort and return EOS_BPNAM (error 215).
2. Offset Calculation for New Files: When calculating play_at for a newly created 0-byte .cas file (cas_total_bytes == 0), play_at evaluated to -1 ((0 * 8) - 1), causing negative bitwise shifts (0x01 << (-1)) when determining the starting bit position.

### Fix
In _cecb_create():
• If fopen(imgfile, "rb+") fails when FAM_WRITE is requested, fall back to fopen(imgfile, "wb+") to create the cassette image file.
• Set play_at = 0 when cas_total_bytes == 0 to ensure clean byte and bit offset initialization.

### Verification
• Unit Tests: Built build/unix and verified all unit tests (librbftest, libdecbtest, libcecbtest, libtoolshedtest, os9commandtest, decbcommandtest) pass.
• ROM Builds: Successfully built cocoroms, dwdos, hdbdos, and superdos targets using cecb copy into new .cas cassette images without pre-touching files.